### PR TITLE
Set key of OppfolgingstilfellePerson to UUID created from PersonIdent

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/kafka/DialogmotekandidatEndringProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/kafka/DialogmotekandidatEndringProducer.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.dialogmotekandidat.domain.toKafkaDialogmotekandidatEndring
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
+import java.util.*
 
 class DialogmotekandidatEndringProducer(
     private val kafkaProducerDialogmotekandidatEndring: KafkaProducer<String, KafkaDialogmotekandidatEndring>,
@@ -12,9 +13,9 @@ class DialogmotekandidatEndringProducer(
     fun sendDialogmotekandidatEndring(
         dialogmotekandidatEndring: DialogmotekandidatEndring,
     ) {
-        val key = dialogmotekandidatEndring.uuid.toString()
+        val kafkaDialogmotekandidatEndring = dialogmotekandidatEndring.toKafkaDialogmotekandidatEndring()
+        val key = UUID.nameUUIDFromBytes(kafkaDialogmotekandidatEndring.personIdentNumber.toByteArray()).toString()
         try {
-            val kafkaDialogmotekandidatEndring = dialogmotekandidatEndring.toKafkaDialogmotekandidatEndring()
             kafkaProducerDialogmotekandidatEndring.send(
                 ProducerRecord(
                     DIALOGMOTEKANDIDAT_TOPIC,


### PR DESCRIPTION
Use UUID based on PersonIdent to ensure that records for a given PersonIdent ends up on the same Kafka partition.