### PR TITLE
Change Stoppunkt from week 16 to week 17

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/domain/DialogmotekandidatStoppunkt.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/domain/DialogmotekandidatStoppunkt.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
 
-const val DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS = 112L
+const val DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS = 119L
 
 enum class DialogmotekandidatStoppunktStatus {
     PLANLAGT_KANDIDAT,


### PR DESCRIPTION
Move Stoppunkt for Dialogmotekandidat from week 16(day 112) to week 17(day 119) to reduce inconsistencies with Arena and avoid generating to many DialogmoteKandidat.