### PR TITLE
Create temporary topic for Dialogmotekandidat

### DIFF
--- a/.github/workflows/kafka-dialogmotekandidat-midlertidig.yaml
+++ b/.github/workflows/kafka-dialogmotekandidat-midlertidig.yaml
@@ -1,0 +1,38 @@
+name: kafka
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/kafka-dialogmotekandidat-midlertidig.yaml'
+      - '.nais/kafka/dialogmotekandidat-midlertidig.yaml'
+      - '.nais/kafka/dev.json'
+      - '.nais/kafka/prod.json'
+
+jobs:
+  deploy-kafka-dialogmotekandidat-midlertidig-dev:
+    name: Deploy Kafka topic Dialogmotekandidat-midlertidig to NAIS dev-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/kafka/dialogmotekandidat-midlertidig.yaml
+          VARS: .nais/kafka/dev.json
+
+  deploy-kafka-dialogmotekandidat-midlertidig-prod:
+    name: Deploy Kafka topic Dialogmotekandidat-midlertidig to NAIS prod-gcp
+    needs: deploy-kafka-dialogmotekandidat-midlertidig-dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: .nais/kafka/dialogmotekandidat-midlertidig.yaml
+          VARS: .nais/kafka/prod.json
+

--- a/.nais/kafka/dialogmotekandidat-midlertidig.yaml
+++ b/.nais/kafka/dialogmotekandidat-midlertidig.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  annotations:
+    dcat.data.nav.no/title: "Dialogmøtekandidat-status for sykmeldte personer. Topic er kun midlertidig for bruk av Syfomotebehov"
+    dcat.data.nav.no/description: >-
+      Topic inneholder informasjon om sykmeldte personer er kandidat for dialogmøte. Topic er kun midlertidig til bruk av av Syfomotebehov, kan slettes etter overgang til topic "isdialogmotekandidat-dialogmotekandidat" i prod.
+  name: isdialogmotekandidat-dialogmotekandidat-midlertidig
+  namespace: teamsykefravr
+  labels:
+    team: teamsykefravr
+spec:
+  pool: {{ kafkaPool }}
+  config:
+    cleanupPolicy: delete
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: -1  # -1 means unlimited
+  acl:
+    - team: teamsykefravr
+      application: isdialogmotekandidat
+      access: readwrite
+    - team: teamsykefravr
+      application: syfomotebehov
+      access: read

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Apply formatting: `./gradlew addKtlintFormatGitPreCommitHook`
 This application produces the following topic(s):
 
 * teamsykefravr.isdialogmotekandidat-dialogmotekandidat
+* teamsykefravr.isdialogmotekandidat-dialogmotekandidat-midlertidig (Topic is created for temporary use, until topic `teamsykefravr.isdialogmotekandidat-dialogmotekandidat` is available in Production.
 
 This application consumes the following topic(s):
 


### PR DESCRIPTION
Create a topic to publish Dialogmotekandidat. This topic is created for use by application Syfomotebehov until topic isdialogmotekandidat-dialogmotekandidat is ready for use in Production. When the topic is ready for use, Syfomotebehov can migrate to it and the temporary topic can be deleted after Syfomotebehov has migrated.