### PR TITLE
Enable Kafka-consumer for dialogmote-statusendring

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -68,7 +68,7 @@ spec:
     - name: TOGGLE_DIALOGMOTEKANDIDAT_STOPPUNKT_CRONJOB_ENABLED
       value: "false"
     - name: TOGGLE_KAFKA_DIALOGMOTE_STATUS_ENDRING_PROCESSING_ENABLED
-      value: "false"
+      value: "true"
     - name: SYFOTILGANGSKONTROLL_CLIENT_ID
       value: "prod-fss.teamsykefravr.syfo-tilgangskontroll"
     - name: SYFOTILGANGSKONTROLL_URL


### PR DESCRIPTION
Dette endrer litt på rekkefølgen Erik foreslo, men siden vi nå lagrer statusendringene på dialogmøter i databasen er det bedre å aktivere denne først.