### PR TITLE
Ikke stoppunkt tilbake i tid for oppfølgingstilfeller som er gyldige nå

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/domain/DialogmotekandidatStoppunkt.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/domain/DialogmotekandidatStoppunkt.kt
@@ -24,19 +24,26 @@ data class DialogmotekandidatStoppunkt private constructor(
     val stoppunktPlanlagt: LocalDate,
 ) {
     companion object {
-        fun stoppunktPlanlagtDato(tilfelleStart: LocalDate): LocalDate =
-            tilfelleStart.plusDays(DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS)
+        fun stoppunktPlanlagtDato(
+            tilfelleStart: LocalDate,
+            tilfelleEnd: LocalDate,
+        ): LocalDate {
+            val stoppunkt = tilfelleStart.plusDays(DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS)
+            val today = LocalDate.now()
+            return if (stoppunkt.isBefore(today) && today.isBefore(tilfelleEnd)) today.plusDays(1) else stoppunkt
+        }
 
         fun planlagt(
             arbeidstakerPersonIdent: PersonIdentNumber,
             tilfelleStart: LocalDate,
+            tilfelleEnd: LocalDate,
         ) = DialogmotekandidatStoppunkt(
             uuid = UUID.randomUUID(),
             createdAt = nowUTC(),
             personIdent = arbeidstakerPersonIdent,
             processedAt = null,
             status = DialogmotekandidatStoppunktStatus.PLANLAGT_KANDIDAT,
-            stoppunktPlanlagt = stoppunktPlanlagtDato(tilfelleStart),
+            stoppunktPlanlagt = stoppunktPlanlagtDato(tilfelleStart, tilfelleEnd),
         )
 
         fun create(pDialogmotekandidatStoppunkt: PDialogmotekandidatStoppunkt) =

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/OppfolgingstilfelleArbeidstaker.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/OppfolgingstilfelleArbeidstaker.kt
@@ -27,7 +27,7 @@ fun OppfolgingstilfelleArbeidstaker.isDialogmotekandidat(
     )
 
 fun OppfolgingstilfelleArbeidstaker.isDialogmotekandidat(): Boolean {
-    val dialogmotekandidatStoppunktPlanlagt = DialogmotekandidatStoppunkt.stoppunktPlanlagtDato(tilfelleStart)
+    val dialogmotekandidatStoppunktPlanlagt = DialogmotekandidatStoppunkt.stoppunktPlanlagtDato(tilfelleStart, tilfelleEnd)
     return tilfelleEnd.isEqual(dialogmotekandidatStoppunktPlanlagt) || tilfelleEnd.isAfter(dialogmotekandidatStoppunktPlanlagt)
 }
 
@@ -35,4 +35,5 @@ fun OppfolgingstilfelleArbeidstaker.toDialogmotekandidatStoppunktPlanlagt() =
     DialogmotekandidatStoppunkt.planlagt(
         arbeidstakerPersonIdent = this.personIdent,
         tilfelleStart = this.tilfelleStart,
+        tilfelleEnd = this.tilfelleEnd,
     )

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -116,17 +116,17 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
             "key2",
             kafkaOppfolgingstilfellePersonNotDialogmotekandidat,
         )
-        val kafkaOppfolgingstilfellePersonNotDialogmotekandidatBackDated = generateKafkaOppfolgingstilfellePerson(
+        val kafkaOppfolgingstilfellePersonTilbakedatert = generateKafkaOppfolgingstilfellePerson(
             personIdentNumber = ARBEIDSTAKER_PERSONIDENTNUMBER,
             start = LocalDate.now().minusDays(110),
             oppfolgingstilfelleDurationInDays = DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS - 1,
         )
-        val kafkaOppfolgingstilfellePersonNotDialogmotekandidatBackDatedRecord = ConsumerRecord(
+        val kafkaOppfolgingstilfellePersonTilbakedatertRecord = ConsumerRecord(
             OPPFOLGINGSTILFELLE_PERSON_TOPIC,
             partition,
             3,
             "key3",
-            kafkaOppfolgingstilfellePersonNotDialogmotekandidatBackDated,
+            kafkaOppfolgingstilfellePersonTilbakedatert,
         )
         val kafkaOppfolgingstilfellePersonDialogmotekandidatLast = generateKafkaOppfolgingstilfellePerson(
             personIdentNumber = ARBEIDSTAKER_PERSONIDENTNUMBER,
@@ -139,17 +139,17 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
             "key4",
             kafkaOppfolgingstilfellePersonDialogmotekandidatLast,
         )
-        val kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLast = generateKafkaOppfolgingstilfellePerson(
+        val kafkaOppfolgingstilfellePersonTilbakedatertLast = generateKafkaOppfolgingstilfellePerson(
             personIdentNumber = ARBEIDSTAKER_PERSONIDENTNUMBER,
             start = LocalDate.now().minusDays(130),
             oppfolgingstilfelleDurationInDays = 140,
         )
-        val kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLastRecord = ConsumerRecord(
+        val kafkaOppfolgingstilfellePersonTilbakedatertLastRecord = ConsumerRecord(
             OPPFOLGINGSTILFELLE_PERSON_TOPIC,
             partition,
             5,
             "key5",
-            kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLast,
+            kafkaOppfolgingstilfellePersonTilbakedatertLast,
         )
 
         val mockKafkaConsumerOppfolgingstilfellePerson =
@@ -272,8 +272,8 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                     every { mockKafkaConsumerOppfolgingstilfellePerson.poll(any<Duration>()) } returns ConsumerRecords(
                         mapOf(
                             oppfolgingstilfelleArbeidstakerTopicPartition to listOf(
-                                kafkaOppfolgingstilfellePersonNotDialogmotekandidatBackDatedRecord,
-                                kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLastRecord,
+                                kafkaOppfolgingstilfellePersonTilbakedatertRecord,
+                                kafkaOppfolgingstilfellePersonTilbakedatertLastRecord,
                             )
                         )
                     )
@@ -297,13 +297,13 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
 
                     assertOppfolgingstilfelleArbeidstaker(
                         oppfolgingstilfelleArbeidstaker = oppfolgingstilfelleArbeidstakerList.first(),
-                        kafkaOppfolgingstilfellePersonDialogmotekandidat = kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLast,
+                        kafkaOppfolgingstilfellePersonDialogmotekandidat = kafkaOppfolgingstilfellePersonTilbakedatertLast,
                     )
 
                     val dialogmotekandidatStoppunktList: List<DialogmotekandidatStoppunkt> =
                         database.getDialogmotekandidatStoppunktList(
                             arbeidstakerPersonIdent = PersonIdentNumber(
-                                kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLast.personIdentNumber
+                                kafkaOppfolgingstilfellePersonTilbakedatertLast.personIdentNumber
                             )
                         ).toDialogmotekandidatStoppunktList()
 
@@ -313,7 +313,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
 
                     val stoppunktPlanlagtExpected = LocalDate.now().plusDays(1)
 
-                    dialogmotekandidatStoppunkt.personIdent.value shouldBeEqualTo kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLast.personIdentNumber
+                    dialogmotekandidatStoppunkt.personIdent.value shouldBeEqualTo kafkaOppfolgingstilfellePersonTilbakedatertLast.personIdentNumber
                     dialogmotekandidatStoppunkt.processedAt.shouldBeNull()
                     dialogmotekandidatStoppunkt.status shouldBeEqualTo DialogmotekandidatStoppunktStatus.PLANLAGT_KANDIDAT
                     dialogmotekandidatStoppunkt.stoppunktPlanlagt shouldBeEqualTo stoppunktPlanlagtExpected

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -107,7 +107,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
         )
         val kafkaOppfolgingstilfellePersonNotDialogmotekandidat = generateKafkaOppfolgingstilfellePerson(
             personIdentNumber = ARBEIDSTAKER_PERSONIDENTNUMBER,
-            oppfolgingstilfelleDurationInDays = DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS - 1
+            oppfolgingstilfelleDurationInDays = DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS - 1,
         )
         val kafkaOppfolgingstilfellePersonNotDialogmotekandidatRecord = ConsumerRecord(
             OPPFOLGINGSTILFELLE_PERSON_TOPIC,
@@ -116,16 +116,40 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
             "key2",
             kafkaOppfolgingstilfellePersonNotDialogmotekandidat,
         )
-        val kafkaOppfolgingstilfellePersonDialogmotekandidatLast = generateKafkaOppfolgingstilfellePerson(
+        val kafkaOppfolgingstilfellePersonNotDialogmotekandidatBackDated = generateKafkaOppfolgingstilfellePerson(
             personIdentNumber = ARBEIDSTAKER_PERSONIDENTNUMBER,
-            oppfolgingstilfelleDurationInDays = DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS + 1
+            start = LocalDate.now().minusDays(110),
+            oppfolgingstilfelleDurationInDays = DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS - 1,
         )
-        val kafkaOppfolgingstilfellePersonDialogmotekandidatLastRecord = ConsumerRecord(
+        val kafkaOppfolgingstilfellePersonNotDialogmotekandidatBackDatedRecord = ConsumerRecord(
             OPPFOLGINGSTILFELLE_PERSON_TOPIC,
             partition,
             3,
             "key3",
+            kafkaOppfolgingstilfellePersonNotDialogmotekandidatBackDated,
+        )
+        val kafkaOppfolgingstilfellePersonDialogmotekandidatLast = generateKafkaOppfolgingstilfellePerson(
+            personIdentNumber = ARBEIDSTAKER_PERSONIDENTNUMBER,
+            oppfolgingstilfelleDurationInDays = DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS + 1,
+        )
+        val kafkaOppfolgingstilfellePersonDialogmotekandidatLastRecord = ConsumerRecord(
+            OPPFOLGINGSTILFELLE_PERSON_TOPIC,
+            partition,
+            4,
+            "key4",
             kafkaOppfolgingstilfellePersonDialogmotekandidatLast,
+        )
+        val kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLast = generateKafkaOppfolgingstilfellePerson(
+            personIdentNumber = ARBEIDSTAKER_PERSONIDENTNUMBER,
+            start = LocalDate.now().minusDays(130),
+            oppfolgingstilfelleDurationInDays = 140,
+        )
+        val kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLastRecord = ConsumerRecord(
+            OPPFOLGINGSTILFELLE_PERSON_TOPIC,
+            partition,
+            5,
+            "key5",
+            kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLast,
         )
 
         val mockKafkaConsumerOppfolgingstilfellePerson =
@@ -242,6 +266,57 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                         dialogmotekandidatStoppunkt = dialogmotekandidatStoppunktList.last(),
                         kafkaOppfolgingstilfellePersonDialogmotekandidat = kafkaOppfolgingstilfellePersonDialogmotekandidatFirst,
                     )
+                }
+
+                it("should not generate stoppunkt back in time for current oppfolgingstilfelle") {
+                    every { mockKafkaConsumerOppfolgingstilfellePerson.poll(any<Duration>()) } returns ConsumerRecords(
+                        mapOf(
+                            oppfolgingstilfelleArbeidstakerTopicPartition to listOf(
+                                kafkaOppfolgingstilfellePersonNotDialogmotekandidatBackDatedRecord,
+                                kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLastRecord,
+                            )
+                        )
+                    )
+
+                    kafkaSyketilfellebitService.pollAndProcessRecords(
+                        kafkaConsumerOppfolgingstilfellePerson = mockKafkaConsumerOppfolgingstilfellePerson,
+                    )
+
+                    verify(exactly = 1) {
+                        mockKafkaConsumerOppfolgingstilfellePerson.commitSync()
+                    }
+
+                    val oppfolgingstilfelleArbeidstakerList: List<OppfolgingstilfelleArbeidstaker?> =
+                        database.getOppfolgingstilfelleArbeidstakerList(
+                            arbeidstakerPersonIdent = PersonIdentNumber(
+                                kafkaOppfolgingstilfellePersonDialogmotekandidatFirst.personIdentNumber
+                            )
+                        ).toOppfolgingstilfelleArbeidstakerList()
+
+                    oppfolgingstilfelleArbeidstakerList.size shouldBeEqualTo 1
+
+                    assertOppfolgingstilfelleArbeidstaker(
+                        oppfolgingstilfelleArbeidstaker = oppfolgingstilfelleArbeidstakerList.first(),
+                        kafkaOppfolgingstilfellePersonDialogmotekandidat = kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLast,
+                    )
+
+                    val dialogmotekandidatStoppunktList: List<DialogmotekandidatStoppunkt> =
+                        database.getDialogmotekandidatStoppunktList(
+                            arbeidstakerPersonIdent = PersonIdentNumber(
+                                kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLast.personIdentNumber
+                            )
+                        ).toDialogmotekandidatStoppunktList()
+
+                    dialogmotekandidatStoppunktList.size shouldBeEqualTo 1
+                    val dialogmotekandidatStoppunkt = dialogmotekandidatStoppunktList.first()
+                    dialogmotekandidatStoppunkt.shouldNotBeNull()
+
+                    val stoppunktPlanlagtExpected = LocalDate.now().plusDays(1)
+
+                    dialogmotekandidatStoppunkt.personIdent.value shouldBeEqualTo kafkaOppfolgingstilfellePersonDialogmotekandidatBackDatedLast.personIdentNumber
+                    dialogmotekandidatStoppunkt.processedAt.shouldBeNull()
+                    dialogmotekandidatStoppunkt.status shouldBeEqualTo DialogmotekandidatStoppunktStatus.PLANLAGT_KANDIDAT
+                    dialogmotekandidatStoppunkt.stoppunktPlanlagt shouldBeEqualTo stoppunktPlanlagtExpected
                 }
 
                 it("should not create OppfolgingstilfellePerson or DialogmotekandidatStoppunkt, if polled 1 that is Dialogmotekandidat, but is not Arbeidstaker at end of tilfelle ") {

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmotekandidatGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmotekandidatGenerator.kt
@@ -10,6 +10,7 @@ fun generateDialogmotekandidatStoppunktPlanlagt(
 ): DialogmotekandidatStoppunkt = DialogmotekandidatStoppunkt.planlagt(
     arbeidstakerPersonIdent = arbeidstakerPersonIdent,
     tilfelleStart = planlagt.minusDays(DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS),
+    tilfelleEnd = planlagt.plusDays(1),
 )
 
 fun generateDialogmotekandidatEndringStoppunkt(

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/KafkaOppfolgingstilfelleArbeidstakerGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/KafkaOppfolgingstilfelleArbeidstakerGenerator.kt
@@ -13,10 +13,10 @@ import java.util.*
 fun generateKafkaOppfolgingstilfellePerson(
     arbeidstakerAtTilfelleEnd: Boolean = true,
     personIdentNumber: PersonIdentNumber = ARBEIDSTAKER_PERSONIDENTNUMBER,
+    start: LocalDate = LocalDate.now().minusDays(1),
     oppfolgingstilfelleDurationInDays: Long,
     virksomhetsnummer: Virksomhetsnummer = VIRKSOMHETSNUMMER_DEFAULT,
 ): KafkaOppfolgingstilfellePerson {
-    val start = LocalDate.now().minusDays(1)
     return KafkaOppfolgingstilfellePerson(
         uuid = UUID.randomUUID().toString(),
         createdAt = nowUTC(),


### PR DESCRIPTION
Siden cronjob'en prosesserer stoppunkter fra dagens dato må vi unngå å generere stoppunkt tilbake i tid for aktuelle (dvs ikke historiske) oppfølgingstilfeller.