### PR TITLE
Forbedre logikk for å finne siste oppfølgingstilfelle

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/database/OppfolgingstilfelleArbeidstakerQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/database/OppfolgingstilfelleArbeidstakerQuery.kt
@@ -55,7 +55,7 @@ const val queryGetOppfolgingstilfelleArbeidstaker =
         SELECT * 
         FROM OPPFOLGINGSTILFELLE_ARBEIDSTAKER
         WHERE personident = ?
-        ORDER BY referanse_tilfelle_bit_inntruffet DESC;
+        ORDER BY tilfelle_end DESC, referanse_tilfelle_bit_inntruffet DESC;
     """
 
 fun DatabaseInterface.getOppfolgingstilfelleArbeidstakerList(


### PR DESCRIPTION
Ser i proddata at det kan komme oppdateringer på gamle oppfølgingstilfeller, så må først sortere på tilfelle_end for å finne det nyeste.