### PR TITLE
Use stoppunkt today instead of tomorrow

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/domain/DialogmotekandidatStoppunkt.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/domain/DialogmotekandidatStoppunkt.kt
@@ -35,7 +35,7 @@ data class DialogmotekandidatStoppunkt private constructor(
             val today = LocalDate.now()
             val stoppunkt = tilfelleStart.plusDays(DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS)
             return if (tilfelleStart.isBefore(ARENA_CUTOFF)) stoppunkt else {
-                if (stoppunkt.isBefore(today) && today.isBefore(tilfelleEnd)) today.plusDays(1) else stoppunkt
+                if (stoppunkt.isBefore(today) && today.isBefore(tilfelleEnd)) today else stoppunkt
             }
         }
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -312,7 +312,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                     val dialogmotekandidatStoppunkt = dialogmotekandidatStoppunktList.first()
                     dialogmotekandidatStoppunkt.shouldNotBeNull()
 
-                    val stoppunktPlanlagtExpected = LocalDate.now().plusDays(1)
+                    val stoppunktPlanlagtExpected = LocalDate.now()
 
                     dialogmotekandidatStoppunkt.personIdent.value shouldBeEqualTo kafkaOppfolgingstilfellePersonTilbakedatertLast.personIdentNumber
                     dialogmotekandidatStoppunkt.processedAt.shouldBeNull()


### PR DESCRIPTION
Endre logikken for "gamle" oppfølgingstilfeller slik at stoppunkt-datoen blir dagens dato. Dette er mest for å forenkle testingen - i produksjon vil det bare resultere i at noen blir kandidat en dag før hva de ellers ville blitt.