### PR TITLE
Create stoppunkt for both current and future tilfelle

### DIFF
--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePerson.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePerson.kt
@@ -24,13 +24,13 @@ data class KafkaOppfolgingstilfelle(
 )
 
 fun KafkaOppfolgingstilfellePerson.toOppfolgingstilfelle(
-    selectedTilfelle: KafkaOppfolgingstilfelle,
+    tilfelle: KafkaOppfolgingstilfelle,
 ) = Oppfolgingstilfelle(
     personIdent = PersonIdentNumber(this.personIdentNumber),
-    tilfelleStart = selectedTilfelle.start,
-    tilfelleEnd = selectedTilfelle.end,
-    arbeidstakerAtTilfelleEnd = selectedTilfelle.arbeidstakerAtTilfelleEnd,
-    virksomhetsnummerList = selectedTilfelle.virksomhetsnummerList.map { Virksomhetsnummer(it) },
+    tilfelleStart = tilfelle.start,
+    tilfelleEnd = tilfelle.end,
+    arbeidstakerAtTilfelleEnd = tilfelle.arbeidstakerAtTilfelleEnd,
+    virksomhetsnummerList = tilfelle.virksomhetsnummerList.map { Virksomhetsnummer(it) },
 )
 
 fun KafkaOppfolgingstilfellePerson.toLatestOppfolgingstilfelle(): Oppfolgingstilfelle? =
@@ -39,7 +39,7 @@ fun KafkaOppfolgingstilfellePerson.toLatestOppfolgingstilfelle(): Oppfolgingstil
     }?.let { latestKafkaOppfolgingstilfelle ->
         if (latestKafkaOppfolgingstilfelle.arbeidstakerAtTilfelleEnd) {
             this.toOppfolgingstilfelle(
-                selectedTilfelle = latestKafkaOppfolgingstilfelle
+                tilfelle = latestKafkaOppfolgingstilfelle
             )
         } else {
             null
@@ -48,12 +48,12 @@ fun KafkaOppfolgingstilfellePerson.toLatestOppfolgingstilfelle(): Oppfolgingstil
 
 fun KafkaOppfolgingstilfellePerson.toCurrentOppfolgingstilfelle(): Oppfolgingstilfelle? {
     val today = LocalDate.now()
-    return this.oppfolgingstilfelleList.filter {
+    return this.oppfolgingstilfelleList.firstOrNull {
         it.start.isBeforeOrEqual(today) && it.end.isAfterOrEqual(today)
-    }.firstOrNull()?.let { currentKafkaOppfolgingstilfelle ->
+    }?.let { currentKafkaOppfolgingstilfelle ->
         if (currentKafkaOppfolgingstilfelle.arbeidstakerAtTilfelleEnd) {
             this.toOppfolgingstilfelle(
-                selectedTilfelle = currentKafkaOppfolgingstilfelle
+                tilfelle = currentKafkaOppfolgingstilfelle
             )
         } else {
             null

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePerson.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePerson.kt
@@ -33,30 +33,28 @@ fun KafkaOppfolgingstilfellePerson.toOppfolgingstilfelle(
     virksomhetsnummerList = tilfelle.virksomhetsnummerList.map { Virksomhetsnummer(it) },
 )
 
-fun KafkaOppfolgingstilfellePerson.toLatestOppfolgingstilfelle(): Oppfolgingstilfelle? =
-    this.oppfolgingstilfelleList.maxByOrNull {
-        it.start
-    }?.let { latestKafkaOppfolgingstilfelle ->
-        if (latestKafkaOppfolgingstilfelle.arbeidstakerAtTilfelleEnd) {
-            this.toOppfolgingstilfelle(
-                tilfelle = latestKafkaOppfolgingstilfelle
-            )
-        } else {
-            null
+fun KafkaOppfolgingstilfellePerson.toLatestOppfolgingstilfelle() =
+    toOppfolgingstilfelleIfArbeidstaker(
+        kafkaOppfolgingstilfelle = this.oppfolgingstilfelleList.maxByOrNull {
+            it.start
         }
-    }
+    )
 
 fun KafkaOppfolgingstilfellePerson.toCurrentOppfolgingstilfelle(): Oppfolgingstilfelle? {
     val today = LocalDate.now()
-    return this.oppfolgingstilfelleList.firstOrNull {
-        it.start.isBeforeOrEqual(today) && it.end.isAfterOrEqual(today)
-    }?.let { currentKafkaOppfolgingstilfelle ->
-        if (currentKafkaOppfolgingstilfelle.arbeidstakerAtTilfelleEnd) {
-            this.toOppfolgingstilfelle(
-                tilfelle = currentKafkaOppfolgingstilfelle
-            )
-        } else {
-            null
+    return toOppfolgingstilfelleIfArbeidstaker(
+        kafkaOppfolgingstilfelle = this.oppfolgingstilfelleList.firstOrNull {
+            it.start.isBeforeOrEqual(today) && it.end.isAfterOrEqual(today)
         }
-    }
+    )
+}
+
+private fun KafkaOppfolgingstilfellePerson.toOppfolgingstilfelleIfArbeidstaker(
+    kafkaOppfolgingstilfelle: KafkaOppfolgingstilfelle?,
+) = if (kafkaOppfolgingstilfelle?.arbeidstakerAtTilfelleEnd == true) {
+    this.toOppfolgingstilfelle(
+        tilfelle = kafkaOppfolgingstilfelle
+    )
+} else {
+    null
 }


### PR DESCRIPTION
Siden vi nå har sluttet å lagre oppfølgingstilfellene i isdialogmotekandidat kan vi lage stoppunkt også for tilfeller som starter i framtiden. Men må passe på at vi også håndterer tilfeller som gjelder for dagens dato i tillegg.