### PR TITLE
Add veiledertilgangskontroll to unntakstatistikk api

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -19,6 +19,7 @@ class VeilederTilgangskontrollClient(
 ) {
     private val httpClient = httpClientDefault()
     private val tilgangskontrollPersonUrl = "${clientEnvironment.baseUrl}$TILGANGSKONTROLL_PERSON_PATH"
+    private val tilgangskontrollPersonListUrl = "${clientEnvironment.baseUrl}$TILGANGSKONTROLL_PERSON_LIST_PATH"
 
     suspend fun hasAccess(
         callId: String,
@@ -43,27 +44,75 @@ class VeilederTilgangskontrollClient(
             if (e.response.status == HttpStatusCode.Forbidden) {
                 COUNT_CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN.increment()
             } else {
-                handleUnexpectedResponseException(e.response, callId)
+                handleUnexpectedResponseException(response = e.response, resource = resourcePerson, callId = callId)
             }
             false
         }
     }
 
+    suspend fun hasAccessToPersonList(
+        personIdentList: List<PersonIdentNumber>,
+        token: String,
+        callId: String,
+    ): List<PersonIdentNumber> {
+        val onBehalfOfToken = azureAdClient.getOnBehalfOfToken(
+            scopeClientId = clientEnvironment.clientId,
+            token = token,
+        )?.accessToken ?: throw RuntimeException("Failed to request access to PersonList: Failed to get OBO token")
+
+        return try {
+            val response: HttpResponse = httpClient.post(tilgangskontrollPersonListUrl) {
+                header(HttpHeaders.Authorization, bearerHeader(token = onBehalfOfToken))
+                header(NAV_CALL_ID_HEADER, value = callId)
+                accept(ContentType.Application.Json)
+                contentType(ContentType.Application.Json)
+                setBody(personIdentList.map { it.value })
+            }
+            COUNT_CALL_TILGANGSKONTROLL_PERSONS_SUCCESS.increment()
+            response.body<List<String>>().map { personIdent -> PersonIdentNumber(personIdent) }
+        } catch (e: ResponseException) {
+            if (e.response.status == HttpStatusCode.Forbidden) {
+                COUNT_CALL_TILGANGSKONTROLL_PERSONS_FORBIDDEN.increment()
+            } else {
+                handleUnexpectedResponseException(response = e.response, resource = resourcePersonList, callId = callId)
+            }
+            emptyList()
+        }
+    }
+
     private fun handleUnexpectedResponseException(
         response: HttpResponse,
+        resource: String,
         callId: String,
     ) {
         log.error(
-            "Error while requesting access to person from syfo-tilgangskontroll with {}, {}",
+            "Error while requesting access to $resource from syfo-tilgangskontroll with {}, {}",
             StructuredArguments.keyValue("statusCode", response.status.value.toString()),
-            StructuredArguments.keyValue("callId", callId)
+            callIdArgument(callId)
         )
-        COUNT_CALL_TILGANGSKONTROLL_PERSON_FAIL.increment()
+        incrementFailCounter(resource)
+    }
+
+    private fun incrementFailCounter(resource: String) {
+        when (resource) {
+            resourcePerson -> {
+                COUNT_CALL_TILGANGSKONTROLL_PERSON_FAIL.increment()
+            }
+
+            resourcePersonList -> {
+                COUNT_CALL_TILGANGSKONTROLL_PERSONS_FAIL.increment()
+            }
+        }
     }
 
     companion object {
         private val log = LoggerFactory.getLogger(VeilederTilgangskontrollClient::class.java)
 
-        const val TILGANGSKONTROLL_PERSON_PATH = "/syfo-tilgangskontroll/api/tilgang/navident/person"
+        private const val resourcePerson = "PERSON"
+        private const val resourcePersonList = "PERSONLIST"
+
+        private const val TILGANGSKONTROLL_COMMON_PATH = "/syfo-tilgangskontroll/api/tilgang/navident"
+        const val TILGANGSKONTROLL_PERSON_PATH = "$TILGANGSKONTROLL_COMMON_PATH/person"
+        const val TILGANGSKONTROLL_PERSON_LIST_PATH = "$TILGANGSKONTROLL_COMMON_PATH/brukere"
     }
 }

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientMetric.kt
@@ -9,6 +9,11 @@ const val CALL_TILGANGSKONTROLL_PERSON_SUCCESS = "${CALL_TILGANGSKONTROLL_PERSON
 const val CALL_TILGANGSKONTROLL_PERSON_FAIL = "${CALL_TILGANGSKONTROLL_PERSON_BASE}_fail_count"
 const val CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN = "${CALL_TILGANGSKONTROLL_PERSON_BASE}_forbidden_count"
 
+const val CALL_TILGANGSKONTROLL_PERSONS_BASE = "${METRICS_NS}_call_tilgangskontroll_persons"
+const val CALL_TILGANGSKONTROLL_PERSONS_SUCCESS = "${CALL_TILGANGSKONTROLL_PERSONS_BASE}_success_count"
+const val CALL_TILGANGSKONTROLL_PERSONS_FAIL = "${CALL_TILGANGSKONTROLL_PERSONS_BASE}_fail_count"
+const val CALL_TILGANGSKONTROLL_PERSONS_FORBIDDEN = "${CALL_TILGANGSKONTROLL_PERSONS_BASE}_forbidden_count"
+
 val COUNT_CALL_TILGANGSKONTROLL_PERSON_SUCCESS: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSON_SUCCESS)
     .description("Counts the number of successful calls to syfo-tilgangskontroll - person")
     .register(METRICS_REGISTRY)
@@ -17,4 +22,14 @@ val COUNT_CALL_TILGANGSKONTROLL_PERSON_FAIL: Counter = Counter.builder(CALL_TILG
     .register(METRICS_REGISTRY)
 val COUNT_CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN)
     .description("Counts the number of forbidden calls to syfo-tilgangskontroll - person")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_TILGANGSKONTROLL_PERSONS_SUCCESS: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSONS_SUCCESS)
+    .description("Counts the number of successful calls to syfo-tilgangskontroll - persons")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_TILGANGSKONTROLL_PERSONS_FAIL: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSONS_FAIL)
+    .description("Counts the number of failed calls to syfo-tilgangskontroll - persons")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_TILGANGSKONTROLL_PERSONS_FORBIDDEN: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSONS_FORBIDDEN)
+    .description("Counts the number of forbidden calls to syfo-tilgangskontroll - persons")
     .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/unntak/UnntakService.kt
+++ b/src/main/kotlin/no/nav/syfo/unntak/UnntakService.kt
@@ -59,20 +59,17 @@ class UnntakService(
     }
 
     suspend fun getUnntakStatistikk(
-        veilederIdent: String,
-        veilederToken: String,
+        unntakList: List<Unntak>,
+        token: String,
         callId: String,
     ): List<UnntakStatistikk> {
-        val unntakForventetFriskmelding = getUnntakForVeileder(veilederIdent).filter { unntak ->
-            unntak.arsak == UnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER
-        }
         val personIdentOppfolgingstilfellerMap = ConcurrentHashMap<PersonIdentNumber, List<Oppfolgingstilfelle>>()
 
-        return unntakForventetFriskmelding.mapNotNull { unntak ->
+        return unntakList.mapNotNull { unntak ->
             val tilfellerForUnntakPerson = personIdentOppfolgingstilfellerMap.getOrPut(unntak.personIdent) {
                 oppfolgingstilfelleService.getAllOppfolgingstilfeller(
                     arbeidstakerPersonIdent = unntak.personIdent,
-                    veilederToken = veilederToken,
+                    veilederToken = token,
                     callId = callId,
                 )
             }
@@ -89,6 +86,6 @@ class UnntakService(
         }
     }
 
-    private fun getUnntakForVeileder(veilderIdent: String): List<Unntak> =
+    internal fun getUnntakForVeileder(veilderIdent: String): List<Unntak> =
         database.getUnntakForVeileder(veilederIdent = veilderIdent).toUnntakList()
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/SyfoTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/SyfoTilgangskontrollMock.kt
@@ -5,6 +5,13 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.client.veiledertilgang.Tilgang
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_2_PERSONIDENTNUMBER
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_3_PERSONIDENTNUMBER
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER_DOD
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER_NOT_KANDIDAT
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER_OLD_KANDIDAT
+import no.nav.syfo.testhelper.UserConstants.FEILENDE_PERSONIDENTNUMBER
 import no.nav.syfo.testhelper.UserConstants.PERSONIDENTNUMBER_VEILEDER_NO_ACCESS
 import no.nav.syfo.util.personIdentHeader
 
@@ -16,10 +23,24 @@ class SyfoTilgangskontrollMock : MockServer() {
                 PERSONIDENTNUMBER_VEILEDER_NO_ACCESS.value -> call.respond(
                     Tilgang(harTilgang = false)
                 )
+
                 else -> call.respond(
                     Tilgang(harTilgang = true)
                 )
             }
+        }
+        post(VeilederTilgangskontrollClient.TILGANGSKONTROLL_PERSON_LIST_PATH) {
+            call.respond(
+                listOf(
+                    ARBEIDSTAKER_PERSONIDENTNUMBER.value,
+                    ARBEIDSTAKER_PERSONIDENTNUMBER_NOT_KANDIDAT.value,
+                    ARBEIDSTAKER_PERSONIDENTNUMBER_OLD_KANDIDAT.value,
+                    ARBEIDSTAKER_PERSONIDENTNUMBER_DOD.value,
+                    ARBEIDSTAKER_2_PERSONIDENTNUMBER.value,
+                    ARBEIDSTAKER_3_PERSONIDENTNUMBER.value,
+                    FEILENDE_PERSONIDENTNUMBER.value,
+                )
+            )
         }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/unntak/UnntakServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/unntak/UnntakServiceSpek.kt
@@ -4,12 +4,10 @@ import io.ktor.server.testing.*
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
-import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.generator.generateNewUnntakDTO
 import no.nav.syfo.unntak.api.domain.toUnntak
-import no.nav.syfo.unntak.database.createUnntak
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -34,25 +32,24 @@ class UnntakServiceSpek : Spek({
                 clearMocks(oppfolgingstilfelleServiceMock, dialogmotekandidatServiceMock)
             }
 
-            fun createUnntak(personIdentNumber: PersonIdentNumber) {
-                val newUnntakDTO = generateNewUnntakDTO(personIdent = personIdentNumber)
-                val unntak = newUnntakDTO.toUnntak(createdByIdent = UserConstants.VEILEDER_IDENT)
-                database.connection.use {
-                    it.createUnntak(unntak)
-                    it.commit()
-                }
-            }
-
             describe("getUnntakStatistikk") {
                 it("Gets oppfolgingstilfeller once for each person with unntak") {
-                    createUnntak(UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER)
-                    createUnntak(UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER_NOT_KANDIDAT)
-                    createUnntak(UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER)
+                    val unntakList = listOf(
+                        generateNewUnntakDTO(personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER).toUnntak(
+                            createdByIdent = UserConstants.VEILEDER_IDENT
+                        ),
+                        generateNewUnntakDTO(personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER_NOT_KANDIDAT).toUnntak(
+                            createdByIdent = UserConstants.VEILEDER_IDENT
+                        ),
+                        generateNewUnntakDTO(personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER).toUnntak(
+                            createdByIdent = UserConstants.VEILEDER_IDENT
+                        )
+                    )
 
                     runBlocking {
                         unntakService.getUnntakStatistikk(
-                            veilederIdent = UserConstants.VEILEDER_IDENT,
-                            veilederToken = "asda",
+                            unntakList = unntakList,
+                            token = "asda",
                             callId = "andsa"
                         )
                     }

--- a/src/test/kotlin/no/nav/syfo/unntak/api/UnntakApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/unntak/api/UnntakApiSpek.kt
@@ -260,6 +260,28 @@ class UnntakApiSpek : Spek({
                             response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
                         }
                     }
+                    it("returns empty unntaksstatistikk if no access to person with unntak") {
+                        val unntak =
+                            generateNewUnntakDTO(personIdent = UserConstants.PERSONIDENTNUMBER_VEILEDER_NO_ACCESS).toUnntak(
+                                createdByIdent = UserConstants.VEILEDER_IDENT
+                            )
+                        database.connection.use {
+                            it.createUnntak(unntak)
+                            it.commit()
+                        }
+
+                        with(
+                            handleRequest(HttpMethod.Get, urlUnntakStatistikk) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+
+                            val unntakStatistikkList =
+                                objectMapper.readValue<List<UnntakStatistikk>>(response.content!!)
+                            unntakStatistikkList.size shouldBeEqualTo 0
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Det kommer av og til noen feil fra `isdialogmotekandidat` fordi den forsøker å hente oppfolgingstilfeller veileder ikke har tilgang til
`io.ktor.client.plugins.ClientRequestException: Client request(GET http://isoppfolgingstilfelle/api/internad/v1/oppfolgingstilfelle/personident) invalid: 403 Forbidden. Text: "Denied NAVIdent access to personIdent: Read OppfolgingstilfelleDTO for Person with PersonIdent"`
Dette kan skyldes at kallet som henter unntaksstatistikk for en veileder spør etter oppfølgingstilfelle for personer som veileder tidligere har satt unntak på, men ikke lenger har tilgang til.