### PR TITLE
Add timers for calls to veiledertilgangskontroll persons and oppfolgingstilfeller for unntak

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/oppfolgingstilfelle/OppfolgingstilfelleMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/oppfolgingstilfelle/OppfolgingstilfelleMetric.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.client.oppfolgingstilfelle
 
 import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Timer
 import no.nav.syfo.application.metric.METRICS_NS
 import no.nav.syfo.application.metric.METRICS_REGISTRY
 
@@ -12,9 +13,15 @@ const val CALL_OPPFOLGINGSTILFELLE_PERSON_FAIL = "${CALL_OPPFOLGINGSTILFELLE_PER
 
 val COUNT_CALL_OPPFOLGINGSTILFELLE_PERSON_SUCCESS: Counter = Counter
     .builder(CALL_OPPFOLGINGSTILFELLE_PERSON_SUCCESS)
-    .description("Counts the number of successful calls to Isoppfolgingstilfelle - OppfolgingstifellePerson")
+    .description("Counts the number of successful calls to Isoppfolgingstilfelle - OppfolgingstilfellePerson")
     .register(METRICS_REGISTRY)
 val COUNT_CALL_OPPFOLGINGSTILFELLE_PERSON_FAIL: Counter = Counter
     .builder(CALL_OPPFOLGINGSTILFELLE_PERSON_FAIL)
-    .description("Counts the number of failed calls to Isoppfolgingstilfelle - OppfolgingstifellePerson")
+    .description("Counts the number of failed calls to Isoppfolgingstilfelle - OppfolgingstilfellePerson")
+    .register(METRICS_REGISTRY)
+
+const val CALL_OPPFOLGINGSTILFELLER_UNNTAK_TIMER = "${CALL_OPPFOLGINGSTILFELLE_BASE}_timer"
+val HISTOGRAM_CALL_OPPFOLGINGSTILFELLER_UNNTAK_TIMER: Timer = Timer
+    .builder(CALL_OPPFOLGINGSTILFELLER_UNNTAK_TIMER)
+    .description("Timer for calls to get oppfolgingstilfeller for unntak")
     .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -12,6 +12,7 @@ import no.nav.syfo.client.httpClientDefault
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.util.*
 import org.slf4j.LoggerFactory
+import java.time.Duration
 
 class VeilederTilgangskontrollClient(
     private val azureAdClient: AzureAdClient,
@@ -60,6 +61,7 @@ class VeilederTilgangskontrollClient(
             token = token,
         )?.accessToken ?: throw RuntimeException("Failed to request access to PersonList: Failed to get OBO token")
 
+        val starttime = System.currentTimeMillis()
         return try {
             val response: HttpResponse = httpClient.post(tilgangskontrollPersonListUrl) {
                 header(HttpHeaders.Authorization, bearerHeader(token = onBehalfOfToken))
@@ -77,6 +79,9 @@ class VeilederTilgangskontrollClient(
                 handleUnexpectedResponseException(response = e.response, resource = resourcePersonList, callId = callId)
             }
             emptyList()
+        } finally {
+            val duration = Duration.ofMillis(System.currentTimeMillis() - starttime)
+            HISTOGRAM_CALL_TILGANGSKONTROLL_PERSONS_TIMER.record(duration)
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientMetric.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.client.veiledertilgang
 
 import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Timer
 import no.nav.syfo.application.metric.METRICS_NS
 import no.nav.syfo.application.metric.METRICS_REGISTRY
 
@@ -32,4 +33,10 @@ val COUNT_CALL_TILGANGSKONTROLL_PERSONS_FAIL: Counter = Counter.builder(CALL_TIL
     .register(METRICS_REGISTRY)
 val COUNT_CALL_TILGANGSKONTROLL_PERSONS_FORBIDDEN: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSONS_FORBIDDEN)
     .description("Counts the number of forbidden calls to syfo-tilgangskontroll - persons")
+    .register(METRICS_REGISTRY)
+
+const val CALL_TILGANGSKONTROLL_PERSONS_TIMER = "${CALL_TILGANGSKONTROLL_PERSONS_BASE}_timer"
+val HISTOGRAM_CALL_TILGANGSKONTROLL_PERSONS_TIMER: Timer = Timer
+    .builder(CALL_TILGANGSKONTROLL_PERSONS_TIMER)
+    .description("Timer for calls to tilgangskontroll persons")
     .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/unntak/UnntakService.kt
+++ b/src/main/kotlin/no/nav/syfo/unntak/UnntakService.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.unntak
 
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.exception.ConflictException
+import no.nav.syfo.client.oppfolgingstilfelle.HISTOGRAM_CALL_OPPFOLGINGSTILFELLER_UNNTAK_TIMER
 import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
 import no.nav.syfo.dialogmotekandidat.database.getDialogmotekandidatEndringListForPerson
 import no.nav.syfo.dialogmotekandidat.database.toDialogmotekandidatEndringList
@@ -14,6 +15,7 @@ import no.nav.syfo.unntak.database.*
 import no.nav.syfo.unntak.database.domain.toUnntakList
 import no.nav.syfo.unntak.domain.*
 import no.nav.syfo.util.toLocalDateOslo
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 
 class UnntakService(
@@ -63,9 +65,34 @@ class UnntakService(
         token: String,
         callId: String,
     ): List<UnntakStatistikk> {
+        val starttime = System.currentTimeMillis()
+        val oppfolgingstilfelleForUnntak = getOppfolgingstilfelleForUnntak(
+            unntakList = unntakList,
+            token = token,
+            callId = callId
+        )
+        val duration = Duration.ofMillis(System.currentTimeMillis() - starttime)
+        HISTOGRAM_CALL_OPPFOLGINGSTILFELLER_UNNTAK_TIMER.record(duration)
+
+        return oppfolgingstilfelleForUnntak.mapNotNull { (unntak, oppfolgingstilfelle) ->
+            oppfolgingstilfelle?.let { tilfelle ->
+                UnntakStatistikk(
+                    unntakDato = unntak.createdAt.toLocalDateOslo(),
+                    tilfelleStart = tilfelle.tilfelleStart,
+                    tilfelleEnd = tilfelle.tilfelleEnd,
+                )
+            }
+        }
+    }
+
+    private suspend fun getOppfolgingstilfelleForUnntak(
+        unntakList: List<Unntak>,
+        token: String,
+        callId: String,
+    ): Map<Unntak, Oppfolgingstilfelle?> {
         val personIdentOppfolgingstilfellerMap = ConcurrentHashMap<PersonIdentNumber, List<Oppfolgingstilfelle>>()
 
-        return unntakList.mapNotNull { unntak ->
+        return unntakList.associateWith { unntak ->
             val tilfellerForUnntakPerson = personIdentOppfolgingstilfellerMap.getOrPut(unntak.personIdent) {
                 oppfolgingstilfelleService.getAllOppfolgingstilfeller(
                     arbeidstakerPersonIdent = unntak.personIdent,
@@ -76,13 +103,7 @@ class UnntakService(
 
             val unntakDato = unntak.createdAt.toLocalDateOslo()
             val tilfelleForUnntak = tilfellerForUnntakPerson.tilfelleForDate(unntakDato)
-            tilfelleForUnntak?.let { tilfelle ->
-                UnntakStatistikk(
-                    unntakDato = unntakDato,
-                    tilfelleStart = tilfelle.tilfelleStart,
-                    tilfelleEnd = tilfelle.tilfelleEnd,
-                )
-            }
+            tilfelleForUnntak
         }
     }
 


### PR DESCRIPTION
For å finne ut av hva som tar tid i unntakstatistikk-apiet (ref https://trello.com/c/B30pV3VS/1474-isdialogmotekandidat-unntakstatistikk-apiet-har-for-lang-responstid)