### PR TITLE
Cronjob for outdated dialogmotekandidater

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -83,3 +83,7 @@ spec:
       value: "https://pdl-api.dev-fss-pub.nais.io/graphql"
     - name: STOPPUNKT_CRONJOB_DELAY
       value: "1"
+    - name: OUTDATED_DIALOGMOTEKANDIDAT_CUTOFF
+      value: "2023-06-01"
+    - name: OUTDATED_DIALOGMOTEKANDIDAT_CRONJOB_ENABLED
+      value: "false"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -83,3 +83,7 @@ spec:
       value: "https://pdl-api.prod-fss-pub.nais.io/graphql"
     - name: STOPPUNKT_CRONJOB_DELAY
       value: "240"
+    - name: OUTDATED_DIALOGMOTEKANDIDAT_CUTOFF
+      value: "2023-06-01"
+    - name: OUTDATED_DIALOGMOTEKANDIDAT_CRONJOB_ENABLED
+      value: "false"

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.application.kafka.KafkaEnvironment
 import no.nav.syfo.client.ClientEnvironment
 import no.nav.syfo.client.ClientsEnvironment
 import no.nav.syfo.client.azuread.AzureEnvironment
+import java.time.LocalDate
 
 const val NAIS_DATABASE_ENV_PREFIX = "NAIS_DATABASE_ISDIALOGMOTEKANDIDAT_ISDIALOGMOTEKANDIDAT_DB"
 
@@ -51,6 +52,8 @@ data class Environment(
         ),
     ),
     val stoppunktCronjobDelay: Long = getEnvVar("STOPPUNKT_CRONJOB_DELAY").toLong(),
+    val outdatedCronjobEnabled: Boolean = getEnvVar("OUTDATED_DIALOGMOTEKANDIDAT_CRONJOB_ENABLED").toBoolean(),
+    val outdatedCutoff: LocalDate = LocalDate.parse(getEnvVar("OUTDATED_DIALOGMOTEKANDIDAT_CUTOFF")),
 )
 
 fun getEnvVar(varName: String, defaultValue: String? = null) =

--- a/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/CronjobModule.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.cronjob
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.backgroundtask.launchBackgroundTask
+import no.nav.syfo.cronjob.dialogmotekandidat.DialogmotekandidatOutdatedCronjob
 import no.nav.syfo.cronjob.dialogmotekandidat.DialogmotekandidatStoppunktCronjob
 import no.nav.syfo.cronjob.leaderelection.LeaderPodClient
 import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
@@ -12,6 +13,7 @@ fun launchCronjobModule(
     environment: Environment,
     dialogmotekandidatService: DialogmotekandidatService,
 ) {
+    val cronjobs = mutableListOf<Cronjob>()
     val leaderPodClient = LeaderPodClient(
         electorPath = environment.electorPath
     )
@@ -23,12 +25,23 @@ fun launchCronjobModule(
         dialogmotekandidatService = dialogmotekandidatService,
         intervalDelayMinutes = environment.stoppunktCronjobDelay,
     )
+    cronjobs.add(dialogmotekandidatStoppunktCronjob)
 
-    launchBackgroundTask(
-        applicationState = applicationState,
-    ) {
-        cronjobRunner.start(
-            cronjob = dialogmotekandidatStoppunktCronjob
+    if (environment.outdatedCronjobEnabled) {
+        val dialogmotekandidatOutdatedCronjob = DialogmotekandidatOutdatedCronjob(
+            outdatedDialogmotekandidatCutoff = environment.outdatedCutoff,
+            dialogmotekandidatService = dialogmotekandidatService,
         )
+        cronjobs.add(dialogmotekandidatOutdatedCronjob)
+    }
+
+    cronjobs.forEach {
+        launchBackgroundTask(
+            applicationState = applicationState,
+        ) {
+            cronjobRunner.start(
+                cronjob = it
+            )
+        }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
@@ -12,7 +12,7 @@ class DialogmotekandidatOutdatedCronjob(
     private val dialogmotekandidatService: DialogmotekandidatService,
 ) : Cronjob {
     override val initialDelayMinutes: Long = 4
-    override val intervalDelayMinutes: Long = 240
+    override val intervalDelayMinutes: Long = 10
 
     override suspend fun run() {
         runJob()

--- a/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
@@ -1,0 +1,43 @@
+package no.nav.syfo.cronjob.dialogmotekandidat
+
+import no.nav.syfo.cronjob.Cronjob
+import no.nav.syfo.cronjob.CronjobResult
+import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
+import no.nav.syfo.dialogmotekandidat.domain.DialogmotekandidatEndring
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+
+class DialogmotekandidatOutdatedCronjob(
+    private val outdatedDialogmotekandidatCutoff: LocalDate,
+    private val dialogmotekandidatService: DialogmotekandidatService,
+) : Cronjob {
+    override val initialDelayMinutes: Long = 4
+    override val intervalDelayMinutes: Long = 240
+
+    override suspend fun run() {
+        runJob()
+    }
+
+    fun runJob(): CronjobResult {
+        val result = CronjobResult()
+
+        val cutoff = outdatedDialogmotekandidatCutoff.atStartOfDay()
+        val outdatedDialogmotekandidater = dialogmotekandidatService.getOutdatedDialogmotekandidater(cutoff)
+        outdatedDialogmotekandidater.forEach {
+            try {
+                val dialogmotekandidatLukket = DialogmotekandidatEndring.lukket(it.personIdentNumber)
+                dialogmotekandidatService.createDialogmotekandidatEndring(dialogmotekandidatLukket)
+                result.updated++
+            } catch (e: Exception) {
+                result.failed++
+                log.error("Got exception when creating dialogmotekandidat-endring LUKKET", e)
+            }
+        }
+
+        return result
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(DialogmotekandidatOutdatedCronjob::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatService.kt
@@ -14,6 +14,7 @@ import no.nav.syfo.unntak.domain.Unntak
 import org.slf4j.LoggerFactory
 import java.sql.Connection
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class DialogmotekandidatService(
     private val oppfolgingstilfelleService: OppfolgingstilfelleService,
@@ -28,6 +29,8 @@ class DialogmotekandidatService(
 
     fun getDialogmotekandidaterWithStoppunktPlanlagtTodayOrYesterday() =
         database.getDialogmotekandidaterWithStoppunktTodayOrYesterday().toDialogmotekandidatStoppunktList()
+
+    fun getOutdatedDialogmotekandidater(cutoff: LocalDateTime) = database.findOutdatedDialogmotekandidater(cutoff).toDialogmotekandidatEndringList()
 
     suspend fun updateDialogmotekandidatStoppunktStatus(
         dialogmotekandidatStoppunkt: DialogmotekandidatStoppunkt,
@@ -76,6 +79,20 @@ class DialogmotekandidatService(
 
             connection.commit()
         }
+    }
+
+    fun createDialogmotekandidatEndring(dialogmotekandidatEndring: DialogmotekandidatEndring) {
+        database.connection.use { connection ->
+            connection.createDialogmotekandidatEndring(
+                dialogmotekandidatEndring = dialogmotekandidatEndring
+            )
+            connection.commit()
+        }
+        dialogmotekandidatEndringProducer.sendDialogmotekandidatEndring(
+            dialogmotekandidatEndring = dialogmotekandidatEndring,
+            tilfelleStart = null,
+            unntak = null,
+        )
     }
 
     fun createDialogmotekandidatEndring(

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatEndringQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatEndringQuery.kt
@@ -62,9 +62,9 @@ fun Connection.getDialogmotekandidatEndringListForPerson(
 const val queryFindOutdatedDialogmotekandidater =
     """
         select * from dialogmotekandidat_endring d
-        where d.created_at = (select max(d2.created_at) from dialogmotekandidat_endring d2 where d2.personident = d.personident group by d.personident)
+        where d.created_at = (select max(d2.created_at) from dialogmotekandidat_endring d2 where d2.personident = d.personident)
         and d.created_at < ? and d.kandidat 
-        LIMIT 100;
+        LIMIT 200;
     """
 
 fun DatabaseInterface.findOutdatedDialogmotekandidater(

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/domain/DialogmotekandidatEndring.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/domain/DialogmotekandidatEndring.kt
@@ -14,6 +14,7 @@ enum class DialogmotekandidatEndringArsak {
     STOPPUNKT,
     DIALOGMOTE_FERDIGSTILT,
     UNNTAK,
+    LUKKET, // TODO: Konsumenter må støtte denne
 }
 
 data class DialogmotekandidatEndring private constructor(
@@ -55,6 +56,14 @@ data class DialogmotekandidatEndring private constructor(
             personIdentNumber = personIdentNumber,
             kandidat = false,
             arsak = DialogmotekandidatEndringArsak.UNNTAK
+        )
+
+        fun lukket(
+            personIdentNumber: PersonIdentNumber,
+        ) = create(
+            personIdentNumber = personIdentNumber,
+            kandidat = false,
+            arsak = DialogmotekandidatEndringArsak.LUKKET
         )
 
         private fun create(

--- a/src/test/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjobSpek.kt
@@ -1,0 +1,243 @@
+package no.nav.syfo.cronjob.dialogmotekandidat
+
+import io.ktor.server.testing.*
+import io.mockk.*
+import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
+import no.nav.syfo.dialogmotekandidat.database.PDialogmotekandidatEndring
+import no.nav.syfo.dialogmotekandidat.database.getDialogmotekandidatEndringListForPerson
+import no.nav.syfo.dialogmotekandidat.domain.DialogmotekandidatEndringArsak
+import no.nav.syfo.dialogmotekandidat.kafka.DialogmotekandidatEndringProducer
+import no.nav.syfo.dialogmotekandidat.kafka.KafkaDialogmotekandidatEndring
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.oppfolgingstilfelle.toOffsetDatetime
+import no.nav.syfo.testhelper.*
+import no.nav.syfo.testhelper.generator.*
+import org.amshove.kluent.*
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
+import java.util.concurrent.Future
+
+class DialogmotekandidatOutdatedCronjobSpek : Spek({
+    with(TestApplicationEngine()) {
+        start()
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val database = externalMockEnvironment.database
+        val kafkaProducer = mockk<KafkaProducer<String, KafkaDialogmotekandidatEndring>>()
+        val dialogmotekandidatEndringProducer = DialogmotekandidatEndringProducer(
+            kafkaProducerDialogmotekandidatEndring = kafkaProducer,
+        )
+        val personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER
+        val cutoff = LocalDate.now()
+        val dialogmotekandidatService = DialogmotekandidatService(
+            oppfolgingstilfelleService = mockk(),
+            dialogmotekandidatEndringProducer = dialogmotekandidatEndringProducer,
+            database = database,
+        )
+        val dialogmotekandidatOutdatedCronjob = DialogmotekandidatOutdatedCronjob(
+            outdatedDialogmotekandidatCutoff = cutoff,
+            dialogmotekandidatService = dialogmotekandidatService,
+        )
+
+        fun getDialogmotekandidatEndringer(personIdent: PersonIdentNumber): List<PDialogmotekandidatEndring> =
+            database.connection.use { connection -> connection.getDialogmotekandidatEndringListForPerson(personIdent) }
+
+        beforeEachTest {
+            database.dropData()
+
+            clearMocks(kafkaProducer)
+            coEvery {
+                kafkaProducer.send(any())
+            } returns mockk<Future<RecordMetadata>>(relaxed = true)
+        }
+
+        describe("${DialogmotekandidatOutdatedCronjob::class.java.simpleName}: run job") {
+            it("creates DialogmotekandidatEndring (LUKKET kandidat=false) for person kandidat before cutoff-date with no other DialogmotekandidatEndring") {
+                val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                    createdAt = cutoff.minusDays(1).toOffsetDatetime()
+                )
+                database.createDialogmotekandidatEndring(kandidatBeforeCutoff)
+
+                val result = dialogmotekandidatOutdatedCronjob.runJob()
+                result.failed shouldBeEqualTo 0
+                result.updated shouldBeEqualTo 1
+
+                val producerRecordSlot = slot<ProducerRecord<String, KafkaDialogmotekandidatEndring>>()
+                verify(exactly = 1) {
+                    kafkaProducer.send(capture(producerRecordSlot))
+                }
+                val kafkaDialogmoteKandidatEndring = producerRecordSlot.captured.value()
+                kafkaDialogmoteKandidatEndring.kandidat shouldBeEqualTo false
+
+                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+                dialogmoteKandidatEndringer.size shouldBeEqualTo 2
+                val latestEndring = dialogmoteKandidatEndringer.first()
+                latestEndring.arsak shouldBeEqualTo DialogmotekandidatEndringArsak.LUKKET.name
+                latestEndring.kandidat shouldBeEqualTo false
+            }
+            it("updates persons kandidat before cutoff-date only once") {
+                val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                    createdAt = cutoff.minusDays(1).toOffsetDatetime()
+                )
+                val otherKandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER_OLD_KANDIDAT).copy(
+                    createdAt = cutoff.minusDays(100).toOffsetDatetime()
+                )
+                val notKandidatBeforeCutoff = generateDialogmotekandidatEndringFerdigstilt(UserConstants.ARBEIDSTAKER_2_PERSONIDENTNUMBER).copy(
+                    createdAt = cutoff.minusDays(50).toOffsetDatetime()
+                )
+                val kandidatAfterCutoff = generateDialogmotekandidatEndringStoppunkt(UserConstants.ARBEIDSTAKER_3_PERSONIDENTNUMBER).copy(
+                    createdAt = cutoff.plusDays(1).toOffsetDatetime()
+                )
+                listOf(
+                    kandidatBeforeCutoff,
+                    otherKandidatBeforeCutoff,
+                    notKandidatBeforeCutoff,
+                    kandidatAfterCutoff
+                ).forEach {
+                    database.createDialogmotekandidatEndring(it)
+                }
+
+                var result = dialogmotekandidatOutdatedCronjob.runJob()
+                result.failed shouldBeEqualTo 0
+                result.updated shouldBeEqualTo 2
+
+                result = dialogmotekandidatOutdatedCronjob.runJob()
+                result.failed shouldBeEqualTo 0
+                result.updated shouldBeEqualTo 0
+            }
+            it("creates no DialogmotekandidatEndring for person with no DialogmotekandidatEndring") {
+                dialogmotekandidatOutdatedCronjob.runJob()
+
+                verify(exactly = 0) {
+                    kafkaProducer.send(any())
+                }
+
+                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+                dialogmoteKandidatEndringer.size shouldBeEqualTo 0
+            }
+            it("creates no DialogmotekandidatEndring for person not kandidat before cutoff-date") {
+                val notKandidatBeforeCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
+                    createdAt = cutoff.minusDays(1).toOffsetDatetime()
+                )
+                database.createDialogmotekandidatEndring(notKandidatBeforeCutoff)
+
+                val result = dialogmotekandidatOutdatedCronjob.runJob()
+                result.failed shouldBeEqualTo 0
+                result.updated shouldBeEqualTo 0
+
+                verify(exactly = 0) {
+                    kafkaProducer.send(any())
+                }
+
+                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+                dialogmoteKandidatEndringer.size shouldBeEqualTo 1
+                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+            }
+            it("creates no DialogmotekandidatEndring for person not kandidat after cutoff-date") {
+                val notKandidatAfterCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
+                    createdAt = cutoff.plusDays(1).toOffsetDatetime()
+                )
+                database.createDialogmotekandidatEndring(notKandidatAfterCutoff)
+
+                val result = dialogmotekandidatOutdatedCronjob.runJob()
+                result.failed shouldBeEqualTo 0
+                result.updated shouldBeEqualTo 0
+
+                verify(exactly = 0) {
+                    kafkaProducer.send(any())
+                }
+
+                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+                dialogmoteKandidatEndringer.size shouldBeEqualTo 1
+                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+            }
+            it("creates no DialogmotekandidatEndring for person kandidat after cutoff-date") {
+                val kandidatAfterCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                    createdAt = cutoff.plusDays(1).toOffsetDatetime()
+                )
+                database.createDialogmotekandidatEndring(kandidatAfterCutoff)
+
+                val result = dialogmotekandidatOutdatedCronjob.runJob()
+                result.failed shouldBeEqualTo 0
+                result.updated shouldBeEqualTo 0
+
+                verify(exactly = 0) {
+                    kafkaProducer.send(any())
+                }
+
+                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+                dialogmoteKandidatEndringer.size shouldBeEqualTo 1
+                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+            }
+            it("creates no DialogmotekandidatEndring for person kandidat before cutoff-date but not kandidat after cutoff-date") {
+                val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                    createdAt = cutoff.minusDays(1).toOffsetDatetime()
+                )
+                val notKandidatAfterCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
+                    createdAt = cutoff.plusDays(1).toOffsetDatetime()
+                )
+                database.createDialogmotekandidatEndring(kandidatBeforeCutoff)
+                database.createDialogmotekandidatEndring(notKandidatAfterCutoff)
+
+                val result = dialogmotekandidatOutdatedCronjob.runJob()
+                result.failed shouldBeEqualTo 0
+                result.updated shouldBeEqualTo 0
+
+                verify(exactly = 0) {
+                    kafkaProducer.send(any())
+                }
+
+                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+                dialogmoteKandidatEndringer.size shouldBeEqualTo 2
+                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+            }
+            it("creates no DialogmotekandidatEndring for person not kandidat before cutoff-date but kandidat after cutoff-date") {
+                val notKandidatBeforeCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
+                    createdAt = cutoff.minusDays(1).toOffsetDatetime(),
+                )
+                val kandidatAfterCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                    createdAt = cutoff.plusDays(1).toOffsetDatetime()
+                )
+                database.createDialogmotekandidatEndring(notKandidatBeforeCutoff)
+                database.createDialogmotekandidatEndring(kandidatAfterCutoff)
+
+                val result = dialogmotekandidatOutdatedCronjob.runJob()
+                result.failed shouldBeEqualTo 0
+                result.updated shouldBeEqualTo 0
+
+                verify(exactly = 0) {
+                    kafkaProducer.send(any())
+                }
+
+                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+                dialogmoteKandidatEndringer.size shouldBeEqualTo 2
+                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+            }
+            it("creates no DialogmotekandidatEndring for person kandidat before cutoff-date but also kandidat after cutoff-date") {
+                val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                    createdAt = cutoff.minusDays(1).toOffsetDatetime()
+                )
+                val kandidatAfterCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                    createdAt = cutoff.plusDays(1).toOffsetDatetime()
+                )
+                database.createDialogmotekandidatEndring(kandidatBeforeCutoff)
+                database.createDialogmotekandidatEndring(kandidatAfterCutoff)
+
+                val result = dialogmotekandidatOutdatedCronjob.runJob()
+                result.failed shouldBeEqualTo 0
+                result.updated shouldBeEqualTo 0
+
+                verify(exactly = 0) {
+                    kafkaProducer.send(any())
+                }
+
+                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+                dialogmoteKandidatEndringer.size shouldBeEqualTo 2
+                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.application.kafka.KafkaEnvironment
 import no.nav.syfo.client.ClientEnvironment
 import no.nav.syfo.client.ClientsEnvironment
 import no.nav.syfo.client.azuread.AzureEnvironment
+import java.time.LocalDate
 
 fun testEnvironment() = Environment(
     database = DatabaseEnvironment(
@@ -47,6 +48,8 @@ fun testEnvironment() = Environment(
         ),
     ),
     stoppunktCronjobDelay = 60L * 4,
+    outdatedCronjobEnabled = true,
+    outdatedCutoff = LocalDate.now().minusYears(1),
 )
 
 fun testAppState() = ApplicationState(


### PR DESCRIPTION
Tanken er at jobben finner siste DialogmotekandidatEndring for alle personer. Sjekker så om den er laget før 1.6.2023 og om kandidat=true.
For disse personene lages det en ny DialogmotekandidatEndring med kandidat=false og årsak=LUKKET.