### PR TITLE
Upgrade db-instance

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -54,6 +54,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: db-custom-1-3840
         databases:
           - name: isdialogmotekandidat-db
         diskAutoresize: true


### PR DESCRIPTION
CloudSQL klager på at db-instansen er for liten, så oppgraderer for prod.