### PR TITLE
IS-2086: Wait seven days before kandidat in api

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -92,7 +92,7 @@ class VeilederTilgangskontrollClient(
         callId: String,
     ) {
         log.error(
-            "Error while requesting access to $resource from syfo-tilgangskontroll with {}, {}",
+            "Error while requesting access to $resource from istilgangskontroll with {}, {}",
             StructuredArguments.keyValue("statusCode", response.status.value.toString()),
             callIdArgument(callId)
         )

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientMetric.kt
@@ -16,23 +16,23 @@ const val CALL_TILGANGSKONTROLL_PERSONS_FAIL = "${CALL_TILGANGSKONTROLL_PERSONS_
 const val CALL_TILGANGSKONTROLL_PERSONS_FORBIDDEN = "${CALL_TILGANGSKONTROLL_PERSONS_BASE}_forbidden_count"
 
 val COUNT_CALL_TILGANGSKONTROLL_PERSON_SUCCESS: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSON_SUCCESS)
-    .description("Counts the number of successful calls to syfo-tilgangskontroll - person")
+    .description("Counts the number of successful calls to istilgangskontroll - person")
     .register(METRICS_REGISTRY)
 val COUNT_CALL_TILGANGSKONTROLL_PERSON_FAIL: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSON_FAIL)
-    .description("Counts the number of failed calls to syfo-tilgangskontroll - person")
+    .description("Counts the number of failed calls to istilgangskontroll - person")
     .register(METRICS_REGISTRY)
 val COUNT_CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN)
-    .description("Counts the number of forbidden calls to syfo-tilgangskontroll - person")
+    .description("Counts the number of forbidden calls to istilgangskontroll - person")
     .register(METRICS_REGISTRY)
 
 val COUNT_CALL_TILGANGSKONTROLL_PERSONS_SUCCESS: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSONS_SUCCESS)
-    .description("Counts the number of successful calls to syfo-tilgangskontroll - persons")
+    .description("Counts the number of successful calls to istilgangskontroll - persons")
     .register(METRICS_REGISTRY)
 val COUNT_CALL_TILGANGSKONTROLL_PERSONS_FAIL: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSONS_FAIL)
-    .description("Counts the number of failed calls to syfo-tilgangskontroll - persons")
+    .description("Counts the number of failed calls to istilgangskontroll - persons")
     .register(METRICS_REGISTRY)
 val COUNT_CALL_TILGANGSKONTROLL_PERSONS_FORBIDDEN: Counter = Counter.builder(CALL_TILGANGSKONTROLL_PERSONS_FORBIDDEN)
-    .description("Counts the number of forbidden calls to syfo-tilgangskontroll - persons")
+    .description("Counts the number of forbidden calls to istilgangskontroll - persons")
     .register(METRICS_REGISTRY)
 
 const val CALL_TILGANGSKONTROLL_PERSONS_TIMER = "${CALL_TILGANGSKONTROLL_PERSONS_BASE}_timer"

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/api/DialogmotekandidatApi.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/api/DialogmotekandidatApi.kt
@@ -40,11 +40,10 @@ fun Route.registerDialogmotekandidatApi(
                 )
                 val kandidatDate = latestKandidatEndring?.createdAt?.toLocalDate()
                 val oppfolgingstilfelleStart = oppfolgingstilfelle?.tilfelleStart
+                val kandidatInOppfolgingstilfelle = oppfolgingstilfelleStart != null && kandidatDate != null && kandidatDate.isAfterOrEqual(oppfolgingstilfelleStart)
+                val sevenDaysPassedSinceKandidat = kandidatDate != null && kandidatDate.isBeforeOrEqual(LocalDate.now().minusDays(7))
 
-                val kandidatDTO = if (kandidatDate != null && oppfolgingstilfelleStart != null &&
-                    kandidatDate.isAfterOrEqual(oppfolgingstilfelleStart) &&
-                    kandidatDate.isBeforeOrEqual(LocalDate.now().minusDays(7))
-                ) {
+                val kandidatDTO = if (kandidatInOppfolgingstilfelle && sevenDaysPassedSinceKandidat) {
                     latestKandidatEndring.toDialogmotekandidatDTO()
                 } else {
                     DialogmotekandidatDTO(

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/api/DialogmotekandidatApi.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/api/DialogmotekandidatApi.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.dialogmotekandidat.domain.toDialogmotekandidatDTO
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
 import no.nav.syfo.util.*
+import java.time.LocalDate
 
 const val kandidatApiBasePath = "/api/internad/v1/kandidat"
 const val kandidatApiPersonidentPath = "/personident"
@@ -41,7 +42,8 @@ fun Route.registerDialogmotekandidatApi(
                 val oppfolgingstilfelleStart = oppfolgingstilfelle?.tilfelleStart
 
                 val kandidatDTO = if (kandidatDate != null && oppfolgingstilfelleStart != null &&
-                    kandidatDate.isAfterOrEqual(oppfolgingstilfelleStart)
+                    kandidatDate.isAfterOrEqual(oppfolgingstilfelleStart) &&
+                    kandidatDate.isBeforeOrEqual(LocalDate.now().minusDays(7))
                 ) {
                     latestKandidatEndring.toDialogmotekandidatDTO()
                 } else {

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/domain/DialogmotekandidatEndring.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/domain/DialogmotekandidatEndring.kt
@@ -14,7 +14,7 @@ enum class DialogmotekandidatEndringArsak {
     STOPPUNKT,
     DIALOGMOTE_FERDIGSTILT,
     UNNTAK,
-    LUKKET, // TODO: Konsumenter må støtte denne
+    LUKKET,
 }
 
 data class DialogmotekandidatEndring private constructor(


### PR DESCRIPTION
Ref beskrivelse i https://github.com/navikt/syfooversiktsrv/pull/352
Endrer i APIet som brukes av syfomodiaperson slik at personen ikke vises som kandidat før det er gått minst syv dager siden personen ble generert som kandidat.