### PR TITLE
IS-2071: Add get dialogmotekandidat from database based on uuid

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -17,6 +17,7 @@ import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.client.wellknown.getWellKnown
 import no.nav.syfo.cronjob.launchCronjobModule
 import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
+import no.nav.syfo.dialogmotekandidat.database.DialogmotekandidatRepository
 import no.nav.syfo.dialogmotekandidat.kafka.DialogmotekandidatEndringProducer
 import no.nav.syfo.dialogmotekandidat.kafka.kafkaDialogmotekandidatEndringProducerConfig
 import no.nav.syfo.dialogmotestatusendring.kafka.KafkaDialogmoteStatusEndringService
@@ -83,6 +84,7 @@ fun main() {
                 oppfolgingstilfelleService = oppfolgingstilfelleService,
                 dialogmotekandidatEndringProducer = dialogmotekandidatEndringProducer,
                 database = applicationDatabase,
+                dialogmotekandidatRepository = DialogmotekandidatRepository(applicationDatabase)
             )
             apiModule(
                 applicationState = applicationState,

--- a/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
@@ -45,5 +45,7 @@ class DialogmotekandidatOutdatedCronjob(
 
     companion object {
         private val log = LoggerFactory.getLogger(DialogmotekandidatOutdatedCronjob::class.java)
+
+        private val uuids = listOf("51081a43-0370-481a-83f9-442ac476897d")
     }
 }

--- a/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
@@ -7,14 +7,14 @@ import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
 import no.nav.syfo.dialogmotekandidat.domain.DialogmotekandidatEndring
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
-import java.util.UUID
+import java.util.*
 
 class DialogmotekandidatOutdatedCronjob(
     private val outdatedDialogmotekandidatCutoff: LocalDate,
     private val dialogmotekandidatService: DialogmotekandidatService,
 ) : Cronjob {
     override val initialDelayMinutes: Long = 4
-    override val intervalDelayMinutes: Long = 10
+    override val intervalDelayMinutes: Long = 60 * 12
 
     override suspend fun run() {
         runJob()
@@ -25,9 +25,8 @@ class DialogmotekandidatOutdatedCronjob(
 
         val cutoff = outdatedDialogmotekandidatCutoff.atStartOfDay()
         val outdatedDialogmotekandidater = dialogmotekandidatService.getOutdatedDialogmotekandidater(cutoff)
-        val dialogmotekandidaterWithUuids =
-            uuids.mapNotNull { dialogmotekandidatService.getDialogmotekandidatEndring(it) }
-        val dialogmotekandidaterToBeRemoved = outdatedDialogmotekandidater + dialogmotekandidaterWithUuids
+        val withGivenUuids = uuids.mapNotNull { dialogmotekandidatService.getDialogmotekandidatEndring(it) }
+        val dialogmotekandidaterToBeRemoved = outdatedDialogmotekandidater + withGivenUuids
 
         dialogmotekandidaterToBeRemoved.forEach {
             try {

--- a/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
@@ -7,6 +7,7 @@ import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
 import no.nav.syfo.dialogmotekandidat.domain.DialogmotekandidatEndring
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
+import java.util.UUID
 
 class DialogmotekandidatOutdatedCronjob(
     private val outdatedDialogmotekandidatCutoff: LocalDate,
@@ -24,7 +25,10 @@ class DialogmotekandidatOutdatedCronjob(
 
         val cutoff = outdatedDialogmotekandidatCutoff.atStartOfDay()
         val outdatedDialogmotekandidater = dialogmotekandidatService.getOutdatedDialogmotekandidater(cutoff)
-        outdatedDialogmotekandidater.forEach {
+        val dialogmotekandidaterWithUuids = uuids.map { dialogmotekandidatService.getDialogmotekandidatEndring(it) }
+        val dialogmotekandidaterToBeRemoved = outdatedDialogmotekandidater + dialogmotekandidaterWithUuids
+
+        dialogmotekandidaterToBeRemoved.forEach {
             try {
                 val dialogmotekandidatLukket = DialogmotekandidatEndring.lukket(it.personIdentNumber)
                 dialogmotekandidatService.createDialogmotekandidatEndring(dialogmotekandidatLukket)
@@ -46,6 +50,6 @@ class DialogmotekandidatOutdatedCronjob(
     companion object {
         private val log = LoggerFactory.getLogger(DialogmotekandidatOutdatedCronjob::class.java)
 
-        private val uuids = listOf("51081a43-0370-481a-83f9-442ac476897d")
+        private val uuids = listOf(UUID.fromString("51081a43-0370-481a-83f9-442ac476897d"))
     }
 }

--- a/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjob.kt
@@ -25,7 +25,8 @@ class DialogmotekandidatOutdatedCronjob(
 
         val cutoff = outdatedDialogmotekandidatCutoff.atStartOfDay()
         val outdatedDialogmotekandidater = dialogmotekandidatService.getOutdatedDialogmotekandidater(cutoff)
-        val dialogmotekandidaterWithUuids = uuids.map { dialogmotekandidatService.getDialogmotekandidatEndring(it) }
+        val dialogmotekandidaterWithUuids =
+            uuids.mapNotNull { dialogmotekandidatService.getDialogmotekandidatEndring(it) }
         val dialogmotekandidaterToBeRemoved = outdatedDialogmotekandidater + dialogmotekandidaterWithUuids
 
         dialogmotekandidaterToBeRemoved.forEach {

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatService.kt
@@ -114,8 +114,8 @@ class DialogmotekandidatService(
         )
     }
 
-    fun getDialogmotekandidatEndring(uuid: UUID): DialogmotekandidatEndring {
-        return dialogmotekandidatRepository.getDialogmotekandidatEndring(uuid = uuid).toDialogmotekandidatEndring()
+    fun getDialogmotekandidatEndring(uuid: UUID): DialogmotekandidatEndring? {
+        return dialogmotekandidatRepository.getDialogmotekandidatEndring(uuid = uuid)?.toDialogmotekandidatEndring()
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatService.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/DialogmotekandidatService.kt
@@ -15,11 +15,13 @@ import org.slf4j.LoggerFactory
 import java.sql.Connection
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 class DialogmotekandidatService(
     private val oppfolgingstilfelleService: OppfolgingstilfelleService,
     private val dialogmotekandidatEndringProducer: DialogmotekandidatEndringProducer,
     private val database: DatabaseInterface,
+    private val dialogmotekandidatRepository: DialogmotekandidatRepository,
 ) {
     fun getLatestDialogmotekandidatEndring(
         personIdent: PersonIdentNumber,
@@ -30,7 +32,8 @@ class DialogmotekandidatService(
     fun getDialogmotekandidaterWithStoppunktPlanlagtTodayOrYesterday() =
         database.getDialogmotekandidaterWithStoppunktTodayOrYesterday().toDialogmotekandidatStoppunktList()
 
-    fun getOutdatedDialogmotekandidater(cutoff: LocalDateTime) = database.findOutdatedDialogmotekandidater(cutoff).toDialogmotekandidatEndringList()
+    fun getOutdatedDialogmotekandidater(cutoff: LocalDateTime) =
+        database.findOutdatedDialogmotekandidater(cutoff).toDialogmotekandidatEndringList()
 
     suspend fun updateDialogmotekandidatStoppunktStatus(
         dialogmotekandidatStoppunkt: DialogmotekandidatStoppunkt,
@@ -109,6 +112,10 @@ class DialogmotekandidatService(
             tilfelleStart = tilfelleStart,
             unntak = unntak,
         )
+    }
+
+    fun getDialogmotekandidatEndring(uuid: UUID): DialogmotekandidatEndring {
+        return dialogmotekandidatRepository.getDialogmotekandidatEndring(uuid = uuid).toDialogmotekandidatEndring()
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatEndringQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatEndringQuery.kt
@@ -6,13 +6,10 @@ import no.nav.syfo.application.database.toList
 import no.nav.syfo.dialogmotekandidat.domain.DialogmotekandidatEndring
 import no.nav.syfo.domain.PersonIdentNumber
 import java.sql.Connection
-import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.OffsetDateTime
 import java.time.ZoneId
-import java.util.*
 
 const val queryCreateDialogmotekandidatEndring =
     """
@@ -75,16 +72,6 @@ fun DatabaseInterface.findOutdatedDialogmotekandidater(
         it.executeQuery().toList { toPDialogmotekandidatEndringList() }
     }
 }
-
-fun ResultSet.toPDialogmotekandidatEndringList() =
-    PDialogmotekandidatEndring(
-        id = getInt("id"),
-        uuid = UUID.fromString(getString("uuid")),
-        createdAt = getObject("created_at", OffsetDateTime::class.java),
-        personIdent = PersonIdentNumber(getString("personident")),
-        kandidat = getBoolean("kandidat"),
-        arsak = getString("arsak"),
-    )
 
 fun LocalDateTime.toInstantOslo(): Instant = toInstant(
     ZoneId.of("Europe/Oslo").rules.getOffset(this)

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatRepository.kt
@@ -1,0 +1,38 @@
+package no.nav.syfo.dialogmotekandidat.database
+
+import no.nav.syfo.application.database.DatabaseInterface
+import no.nav.syfo.application.database.toList
+import no.nav.syfo.domain.PersonIdentNumber
+import java.sql.ResultSet
+import java.time.OffsetDateTime
+import java.util.*
+
+class DialogmotekandidatRepository(private val database: DatabaseInterface) {
+
+    fun getDialogmotekandidatEndring(uuid: UUID): PDialogmotekandidatEndring =
+        database.connection.use { connection ->
+            connection.prepareStatement(GET_DIALOGMOTEENDRING_QUERY).use {
+                it.setString(1, uuid.toString())
+                it.executeQuery().toList { toPDialogmotekandidatEndringList() }
+            }
+        }.first()
+
+    companion object {
+        private const val GET_DIALOGMOTEENDRING_QUERY =
+            """
+                SELECT * 
+                FROM DIALOGMOTEKANDIDAT_ENDRING
+                WHERE uuid = ?
+            """
+    }
+}
+
+fun ResultSet.toPDialogmotekandidatEndringList() =
+    PDialogmotekandidatEndring(
+        id = getInt("id"),
+        uuid = UUID.fromString(getString("uuid")),
+        createdAt = getObject("created_at", OffsetDateTime::class.java),
+        personIdent = PersonIdentNumber(getString("personident")),
+        kandidat = getBoolean("kandidat"),
+        arsak = getString("arsak"),
+    )

--- a/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatRepository.kt
@@ -9,13 +9,13 @@ import java.util.*
 
 class DialogmotekandidatRepository(private val database: DatabaseInterface) {
 
-    fun getDialogmotekandidatEndring(uuid: UUID): PDialogmotekandidatEndring =
+    fun getDialogmotekandidatEndring(uuid: UUID): PDialogmotekandidatEndring? =
         database.connection.use { connection ->
             connection.prepareStatement(GET_DIALOGMOTEENDRING_QUERY).use {
                 it.setString(1, uuid.toString())
                 it.executeQuery().toList { toPDialogmotekandidatEndringList() }
             }
-        }.first()
+        }.firstOrNull()
 
     companion object {
         private const val GET_DIALOGMOTEENDRING_QUERY =

--- a/src/test/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjobSpek.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.cronjob.dialogmotekandidat
 import io.ktor.server.testing.*
 import io.mockk.*
 import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
+import no.nav.syfo.dialogmotekandidat.database.DialogmotekandidatRepository
 import no.nav.syfo.dialogmotekandidat.database.PDialogmotekandidatEndring
 import no.nav.syfo.dialogmotekandidat.database.getDialogmotekandidatEndringListForPerson
 import no.nav.syfo.dialogmotekandidat.domain.DialogmotekandidatEndringArsak
@@ -36,6 +37,7 @@ class DialogmotekandidatOutdatedCronjobSpek : Spek({
             oppfolgingstilfelleService = mockk(),
             dialogmotekandidatEndringProducer = dialogmotekandidatEndringProducer,
             database = database,
+            dialogmotekandidatRepository = DialogmotekandidatRepository(database),
         )
         val dialogmotekandidatOutdatedCronjob = DialogmotekandidatOutdatedCronjob(
             outdatedDialogmotekandidatCutoff = cutoff,
@@ -82,15 +84,18 @@ class DialogmotekandidatOutdatedCronjobSpek : Spek({
                 val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
                     createdAt = cutoff.minusDays(1).toOffsetDatetime()
                 )
-                val otherKandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER_OLD_KANDIDAT).copy(
-                    createdAt = cutoff.minusDays(100).toOffsetDatetime()
-                )
-                val notKandidatBeforeCutoff = generateDialogmotekandidatEndringFerdigstilt(UserConstants.ARBEIDSTAKER_2_PERSONIDENTNUMBER).copy(
-                    createdAt = cutoff.minusDays(50).toOffsetDatetime()
-                )
-                val kandidatAfterCutoff = generateDialogmotekandidatEndringStoppunkt(UserConstants.ARBEIDSTAKER_3_PERSONIDENTNUMBER).copy(
-                    createdAt = cutoff.plusDays(1).toOffsetDatetime()
-                )
+                val otherKandidatBeforeCutoff =
+                    generateDialogmotekandidatEndringStoppunkt(UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER_OLD_KANDIDAT).copy(
+                        createdAt = cutoff.minusDays(100).toOffsetDatetime()
+                    )
+                val notKandidatBeforeCutoff =
+                    generateDialogmotekandidatEndringFerdigstilt(UserConstants.ARBEIDSTAKER_2_PERSONIDENTNUMBER).copy(
+                        createdAt = cutoff.minusDays(50).toOffsetDatetime()
+                    )
+                val kandidatAfterCutoff =
+                    generateDialogmotekandidatEndringStoppunkt(UserConstants.ARBEIDSTAKER_3_PERSONIDENTNUMBER).copy(
+                        createdAt = cutoff.plusDays(1).toOffsetDatetime()
+                    )
                 listOf(
                     kandidatBeforeCutoff,
                     otherKandidatBeforeCutoff,

--- a/src/test/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjobSpek.kt
@@ -1,6 +1,5 @@
 package no.nav.syfo.cronjob.dialogmotekandidat
 
-import io.ktor.server.testing.*
 import io.mockk.*
 import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
 import no.nav.syfo.dialogmotekandidat.database.DialogmotekandidatRepository
@@ -11,9 +10,13 @@ import no.nav.syfo.dialogmotekandidat.kafka.DialogmotekandidatEndringProducer
 import no.nav.syfo.dialogmotekandidat.kafka.KafkaDialogmotekandidatEndring
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.oppfolgingstilfelle.toOffsetDatetime
-import no.nav.syfo.testhelper.*
-import no.nav.syfo.testhelper.generator.*
-import org.amshove.kluent.*
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.createDialogmotekandidatEndring
+import no.nav.syfo.testhelper.dropData
+import no.nav.syfo.testhelper.generator.generateDialogmotekandidatEndringFerdigstilt
+import no.nav.syfo.testhelper.generator.generateDialogmotekandidatEndringStoppunkt
+import org.amshove.kluent.shouldBeEqualTo
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
@@ -23,226 +26,223 @@ import java.time.LocalDate
 import java.util.concurrent.Future
 
 class DialogmotekandidatOutdatedCronjobSpek : Spek({
-    with(TestApplicationEngine()) {
-        start()
-        val externalMockEnvironment = ExternalMockEnvironment.instance
-        val database = externalMockEnvironment.database
-        val kafkaProducer = mockk<KafkaProducer<String, KafkaDialogmotekandidatEndring>>()
-        val dialogmotekandidatEndringProducer = DialogmotekandidatEndringProducer(
-            kafkaProducerDialogmotekandidatEndring = kafkaProducer,
-        )
-        val personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER
-        val cutoff = LocalDate.now()
-        val dialogmotekandidatService = DialogmotekandidatService(
-            oppfolgingstilfelleService = mockk(),
-            dialogmotekandidatEndringProducer = dialogmotekandidatEndringProducer,
-            database = database,
-            dialogmotekandidatRepository = DialogmotekandidatRepository(database),
-        )
-        val dialogmotekandidatOutdatedCronjob = DialogmotekandidatOutdatedCronjob(
-            outdatedDialogmotekandidatCutoff = cutoff,
-            dialogmotekandidatService = dialogmotekandidatService,
-        )
+    val externalMockEnvironment = ExternalMockEnvironment.instance
+    val database = externalMockEnvironment.database
+    val kafkaProducer = mockk<KafkaProducer<String, KafkaDialogmotekandidatEndring>>()
+    val dialogmotekandidatEndringProducer = DialogmotekandidatEndringProducer(
+        kafkaProducerDialogmotekandidatEndring = kafkaProducer,
+    )
+    val personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER
+    val cutoff = LocalDate.now()
+    val dialogmotekandidatService = DialogmotekandidatService(
+        oppfolgingstilfelleService = mockk(),
+        dialogmotekandidatEndringProducer = dialogmotekandidatEndringProducer,
+        database = database,
+        dialogmotekandidatRepository = DialogmotekandidatRepository(database),
+    )
+    val dialogmotekandidatOutdatedCronjob = DialogmotekandidatOutdatedCronjob(
+        outdatedDialogmotekandidatCutoff = cutoff,
+        dialogmotekandidatService = dialogmotekandidatService,
+    )
 
-        fun getDialogmotekandidatEndringer(personIdent: PersonIdentNumber): List<PDialogmotekandidatEndring> =
-            database.connection.use { connection -> connection.getDialogmotekandidatEndringListForPerson(personIdent) }
+    fun getDialogmotekandidatEndringer(personIdent: PersonIdentNumber): List<PDialogmotekandidatEndring> =
+        database.connection.use { connection -> connection.getDialogmotekandidatEndringListForPerson(personIdent) }
 
-        beforeEachTest {
-            database.dropData()
+    beforeEachTest {
+        database.dropData()
 
-            clearMocks(kafkaProducer)
-            coEvery {
-                kafkaProducer.send(any())
-            } returns mockk<Future<RecordMetadata>>(relaxed = true)
+        clearMocks(kafkaProducer)
+        coEvery {
+            kafkaProducer.send(any())
+        } returns mockk<Future<RecordMetadata>>(relaxed = true)
+    }
+
+    describe("${DialogmotekandidatOutdatedCronjob::class.java.simpleName}: run job") {
+        it("creates DialogmotekandidatEndring (LUKKET kandidat=false) for person kandidat before cutoff-date with no other DialogmotekandidatEndring") {
+            val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                createdAt = cutoff.minusDays(1).toOffsetDatetime()
+            )
+            database.createDialogmotekandidatEndring(kandidatBeforeCutoff)
+
+            val result = dialogmotekandidatOutdatedCronjob.runJob()
+            result.failed shouldBeEqualTo 0
+            result.updated shouldBeEqualTo 1
+
+            val producerRecordSlot = slot<ProducerRecord<String, KafkaDialogmotekandidatEndring>>()
+            verify(exactly = 1) {
+                kafkaProducer.send(capture(producerRecordSlot))
+            }
+            val kafkaDialogmoteKandidatEndring = producerRecordSlot.captured.value()
+            kafkaDialogmoteKandidatEndring.kandidat shouldBeEqualTo false
+
+            val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+            dialogmoteKandidatEndringer.size shouldBeEqualTo 2
+            val latestEndring = dialogmoteKandidatEndringer.first()
+            latestEndring.arsak shouldBeEqualTo DialogmotekandidatEndringArsak.LUKKET.name
+            latestEndring.kandidat shouldBeEqualTo false
         }
-
-        describe("${DialogmotekandidatOutdatedCronjob::class.java.simpleName}: run job") {
-            it("creates DialogmotekandidatEndring (LUKKET kandidat=false) for person kandidat before cutoff-date with no other DialogmotekandidatEndring") {
-                val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
-                    createdAt = cutoff.minusDays(1).toOffsetDatetime()
+        it("updates persons kandidat before cutoff-date only once") {
+            val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                createdAt = cutoff.minusDays(1).toOffsetDatetime()
+            )
+            val otherKandidatBeforeCutoff =
+                generateDialogmotekandidatEndringStoppunkt(UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER_OLD_KANDIDAT).copy(
+                    createdAt = cutoff.minusDays(100).toOffsetDatetime()
                 )
-                database.createDialogmotekandidatEndring(kandidatBeforeCutoff)
-
-                val result = dialogmotekandidatOutdatedCronjob.runJob()
-                result.failed shouldBeEqualTo 0
-                result.updated shouldBeEqualTo 1
-
-                val producerRecordSlot = slot<ProducerRecord<String, KafkaDialogmotekandidatEndring>>()
-                verify(exactly = 1) {
-                    kafkaProducer.send(capture(producerRecordSlot))
-                }
-                val kafkaDialogmoteKandidatEndring = producerRecordSlot.captured.value()
-                kafkaDialogmoteKandidatEndring.kandidat shouldBeEqualTo false
-
-                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
-                dialogmoteKandidatEndringer.size shouldBeEqualTo 2
-                val latestEndring = dialogmoteKandidatEndringer.first()
-                latestEndring.arsak shouldBeEqualTo DialogmotekandidatEndringArsak.LUKKET.name
-                latestEndring.kandidat shouldBeEqualTo false
-            }
-            it("updates persons kandidat before cutoff-date only once") {
-                val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
-                    createdAt = cutoff.minusDays(1).toOffsetDatetime()
+            val notKandidatBeforeCutoff =
+                generateDialogmotekandidatEndringFerdigstilt(UserConstants.ARBEIDSTAKER_2_PERSONIDENTNUMBER).copy(
+                    createdAt = cutoff.minusDays(50).toOffsetDatetime()
                 )
-                val otherKandidatBeforeCutoff =
-                    generateDialogmotekandidatEndringStoppunkt(UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER_OLD_KANDIDAT).copy(
-                        createdAt = cutoff.minusDays(100).toOffsetDatetime()
-                    )
-                val notKandidatBeforeCutoff =
-                    generateDialogmotekandidatEndringFerdigstilt(UserConstants.ARBEIDSTAKER_2_PERSONIDENTNUMBER).copy(
-                        createdAt = cutoff.minusDays(50).toOffsetDatetime()
-                    )
-                val kandidatAfterCutoff =
-                    generateDialogmotekandidatEndringStoppunkt(UserConstants.ARBEIDSTAKER_3_PERSONIDENTNUMBER).copy(
-                        createdAt = cutoff.plusDays(1).toOffsetDatetime()
-                    )
-                listOf(
-                    kandidatBeforeCutoff,
-                    otherKandidatBeforeCutoff,
-                    notKandidatBeforeCutoff,
-                    kandidatAfterCutoff
-                ).forEach {
-                    database.createDialogmotekandidatEndring(it)
-                }
-
-                var result = dialogmotekandidatOutdatedCronjob.runJob()
-                result.failed shouldBeEqualTo 0
-                result.updated shouldBeEqualTo 2
-
-                result = dialogmotekandidatOutdatedCronjob.runJob()
-                result.failed shouldBeEqualTo 0
-                result.updated shouldBeEqualTo 0
-            }
-            it("creates no DialogmotekandidatEndring for person with no DialogmotekandidatEndring") {
-                dialogmotekandidatOutdatedCronjob.runJob()
-
-                verify(exactly = 0) {
-                    kafkaProducer.send(any())
-                }
-
-                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
-                dialogmoteKandidatEndringer.size shouldBeEqualTo 0
-            }
-            it("creates no DialogmotekandidatEndring for person not kandidat before cutoff-date") {
-                val notKandidatBeforeCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
-                    createdAt = cutoff.minusDays(1).toOffsetDatetime()
-                )
-                database.createDialogmotekandidatEndring(notKandidatBeforeCutoff)
-
-                val result = dialogmotekandidatOutdatedCronjob.runJob()
-                result.failed shouldBeEqualTo 0
-                result.updated shouldBeEqualTo 0
-
-                verify(exactly = 0) {
-                    kafkaProducer.send(any())
-                }
-
-                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
-                dialogmoteKandidatEndringer.size shouldBeEqualTo 1
-                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
-            }
-            it("creates no DialogmotekandidatEndring for person not kandidat after cutoff-date") {
-                val notKandidatAfterCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
+            val kandidatAfterCutoff =
+                generateDialogmotekandidatEndringStoppunkt(UserConstants.ARBEIDSTAKER_3_PERSONIDENTNUMBER).copy(
                     createdAt = cutoff.plusDays(1).toOffsetDatetime()
                 )
-                database.createDialogmotekandidatEndring(notKandidatAfterCutoff)
-
-                val result = dialogmotekandidatOutdatedCronjob.runJob()
-                result.failed shouldBeEqualTo 0
-                result.updated shouldBeEqualTo 0
-
-                verify(exactly = 0) {
-                    kafkaProducer.send(any())
-                }
-
-                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
-                dialogmoteKandidatEndringer.size shouldBeEqualTo 1
-                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+            listOf(
+                kandidatBeforeCutoff,
+                otherKandidatBeforeCutoff,
+                notKandidatBeforeCutoff,
+                kandidatAfterCutoff
+            ).forEach {
+                database.createDialogmotekandidatEndring(it)
             }
-            it("creates no DialogmotekandidatEndring for person kandidat after cutoff-date") {
-                val kandidatAfterCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
-                    createdAt = cutoff.plusDays(1).toOffsetDatetime()
-                )
-                database.createDialogmotekandidatEndring(kandidatAfterCutoff)
 
-                val result = dialogmotekandidatOutdatedCronjob.runJob()
-                result.failed shouldBeEqualTo 0
-                result.updated shouldBeEqualTo 0
+            var result = dialogmotekandidatOutdatedCronjob.runJob()
+            result.failed shouldBeEqualTo 0
+            result.updated shouldBeEqualTo 2
 
-                verify(exactly = 0) {
-                    kafkaProducer.send(any())
-                }
+            result = dialogmotekandidatOutdatedCronjob.runJob()
+            result.failed shouldBeEqualTo 0
+            result.updated shouldBeEqualTo 0
+        }
+        it("creates no DialogmotekandidatEndring for person with no DialogmotekandidatEndring") {
+            dialogmotekandidatOutdatedCronjob.runJob()
 
-                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
-                dialogmoteKandidatEndringer.size shouldBeEqualTo 1
-                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+            verify(exactly = 0) {
+                kafkaProducer.send(any())
             }
-            it("creates no DialogmotekandidatEndring for person kandidat before cutoff-date but not kandidat after cutoff-date") {
-                val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
-                    createdAt = cutoff.minusDays(1).toOffsetDatetime()
-                )
-                val notKandidatAfterCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
-                    createdAt = cutoff.plusDays(1).toOffsetDatetime()
-                )
-                database.createDialogmotekandidatEndring(kandidatBeforeCutoff)
-                database.createDialogmotekandidatEndring(notKandidatAfterCutoff)
 
-                val result = dialogmotekandidatOutdatedCronjob.runJob()
-                result.failed shouldBeEqualTo 0
-                result.updated shouldBeEqualTo 0
+            val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+            dialogmoteKandidatEndringer.size shouldBeEqualTo 0
+        }
+        it("creates no DialogmotekandidatEndring for person not kandidat before cutoff-date") {
+            val notKandidatBeforeCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
+                createdAt = cutoff.minusDays(1).toOffsetDatetime()
+            )
+            database.createDialogmotekandidatEndring(notKandidatBeforeCutoff)
 
-                verify(exactly = 0) {
-                    kafkaProducer.send(any())
-                }
+            val result = dialogmotekandidatOutdatedCronjob.runJob()
+            result.failed shouldBeEqualTo 0
+            result.updated shouldBeEqualTo 0
 
-                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
-                dialogmoteKandidatEndringer.size shouldBeEqualTo 2
-                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+            verify(exactly = 0) {
+                kafkaProducer.send(any())
             }
-            it("creates no DialogmotekandidatEndring for person not kandidat before cutoff-date but kandidat after cutoff-date") {
-                val notKandidatBeforeCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
-                    createdAt = cutoff.minusDays(1).toOffsetDatetime(),
-                )
-                val kandidatAfterCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
-                    createdAt = cutoff.plusDays(1).toOffsetDatetime()
-                )
-                database.createDialogmotekandidatEndring(notKandidatBeforeCutoff)
-                database.createDialogmotekandidatEndring(kandidatAfterCutoff)
 
-                val result = dialogmotekandidatOutdatedCronjob.runJob()
-                result.failed shouldBeEqualTo 0
-                result.updated shouldBeEqualTo 0
+            val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+            dialogmoteKandidatEndringer.size shouldBeEqualTo 1
+            dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+        }
+        it("creates no DialogmotekandidatEndring for person not kandidat after cutoff-date") {
+            val notKandidatAfterCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
+                createdAt = cutoff.plusDays(1).toOffsetDatetime()
+            )
+            database.createDialogmotekandidatEndring(notKandidatAfterCutoff)
 
-                verify(exactly = 0) {
-                    kafkaProducer.send(any())
-                }
+            val result = dialogmotekandidatOutdatedCronjob.runJob()
+            result.failed shouldBeEqualTo 0
+            result.updated shouldBeEqualTo 0
 
-                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
-                dialogmoteKandidatEndringer.size shouldBeEqualTo 2
-                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+            verify(exactly = 0) {
+                kafkaProducer.send(any())
             }
-            it("creates no DialogmotekandidatEndring for person kandidat before cutoff-date but also kandidat after cutoff-date") {
-                val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
-                    createdAt = cutoff.minusDays(1).toOffsetDatetime()
-                )
-                val kandidatAfterCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
-                    createdAt = cutoff.plusDays(1).toOffsetDatetime()
-                )
-                database.createDialogmotekandidatEndring(kandidatBeforeCutoff)
-                database.createDialogmotekandidatEndring(kandidatAfterCutoff)
 
-                val result = dialogmotekandidatOutdatedCronjob.runJob()
-                result.failed shouldBeEqualTo 0
-                result.updated shouldBeEqualTo 0
+            val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+            dialogmoteKandidatEndringer.size shouldBeEqualTo 1
+            dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+        }
+        it("creates no DialogmotekandidatEndring for person kandidat after cutoff-date") {
+            val kandidatAfterCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                createdAt = cutoff.plusDays(1).toOffsetDatetime()
+            )
+            database.createDialogmotekandidatEndring(kandidatAfterCutoff)
 
-                verify(exactly = 0) {
-                    kafkaProducer.send(any())
-                }
+            val result = dialogmotekandidatOutdatedCronjob.runJob()
+            result.failed shouldBeEqualTo 0
+            result.updated shouldBeEqualTo 0
 
-                val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
-                dialogmoteKandidatEndringer.size shouldBeEqualTo 2
-                dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+            verify(exactly = 0) {
+                kafkaProducer.send(any())
             }
+
+            val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+            dialogmoteKandidatEndringer.size shouldBeEqualTo 1
+            dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+        }
+        it("creates no DialogmotekandidatEndring for person kandidat before cutoff-date but not kandidat after cutoff-date") {
+            val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                createdAt = cutoff.minusDays(1).toOffsetDatetime()
+            )
+            val notKandidatAfterCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
+                createdAt = cutoff.plusDays(1).toOffsetDatetime()
+            )
+            database.createDialogmotekandidatEndring(kandidatBeforeCutoff)
+            database.createDialogmotekandidatEndring(notKandidatAfterCutoff)
+
+            val result = dialogmotekandidatOutdatedCronjob.runJob()
+            result.failed shouldBeEqualTo 0
+            result.updated shouldBeEqualTo 0
+
+            verify(exactly = 0) {
+                kafkaProducer.send(any())
+            }
+
+            val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+            dialogmoteKandidatEndringer.size shouldBeEqualTo 2
+            dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+        }
+        it("creates no DialogmotekandidatEndring for person not kandidat before cutoff-date but kandidat after cutoff-date") {
+            val notKandidatBeforeCutoff = generateDialogmotekandidatEndringFerdigstilt(personIdent).copy(
+                createdAt = cutoff.minusDays(1).toOffsetDatetime(),
+            )
+            val kandidatAfterCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                createdAt = cutoff.plusDays(1).toOffsetDatetime()
+            )
+            database.createDialogmotekandidatEndring(notKandidatBeforeCutoff)
+            database.createDialogmotekandidatEndring(kandidatAfterCutoff)
+
+            val result = dialogmotekandidatOutdatedCronjob.runJob()
+            result.failed shouldBeEqualTo 0
+            result.updated shouldBeEqualTo 0
+
+            verify(exactly = 0) {
+                kafkaProducer.send(any())
+            }
+
+            val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+            dialogmoteKandidatEndringer.size shouldBeEqualTo 2
+            dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
+        }
+        it("creates no DialogmotekandidatEndring for person kandidat before cutoff-date but also kandidat after cutoff-date") {
+            val kandidatBeforeCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                createdAt = cutoff.minusDays(1).toOffsetDatetime()
+            )
+            val kandidatAfterCutoff = generateDialogmotekandidatEndringStoppunkt(personIdent).copy(
+                createdAt = cutoff.plusDays(1).toOffsetDatetime()
+            )
+            database.createDialogmotekandidatEndring(kandidatBeforeCutoff)
+            database.createDialogmotekandidatEndring(kandidatAfterCutoff)
+
+            val result = dialogmotekandidatOutdatedCronjob.runJob()
+            result.failed shouldBeEqualTo 0
+            result.updated shouldBeEqualTo 0
+
+            verify(exactly = 0) {
+                kafkaProducer.send(any())
+            }
+
+            val dialogmoteKandidatEndringer = getDialogmotekandidatEndringer(personIdent)
+            dialogmoteKandidatEndringer.size shouldBeEqualTo 2
+            dialogmoteKandidatEndringer.none { it.arsak == DialogmotekandidatEndringArsak.LUKKET.name }
         }
     }
 })

--- a/src/test/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatRepositorySpek.kt
@@ -26,14 +26,17 @@ class DialogmotekandidatRepositorySpek : Spek({
 
             describe("Successfully gets a dialogmotekandidatendring") {
                 val dialogmoteKandidatEndring = generateDialogmotekandidatEndringStoppunkt(kandidatPersonIdent)
-                database.connection.createDialogmotekandidatEndring(dialogmotekandidatEndring = dialogmoteKandidatEndring)
+                database.connection.use { connection ->
+                    connection.createDialogmotekandidatEndring(dialogmotekandidatEndring = dialogmoteKandidatEndring)
+                    connection.commit()
+                }
 
                 val insertedDialogmotekandidatEndring =
                     dialogmotekandidatRepository.getDialogmotekandidatEndring(dialogmoteKandidatEndring.uuid)
-                insertedDialogmotekandidatEndring.personIdent shouldBeEqualTo dialogmoteKandidatEndring.personIdentNumber
-                insertedDialogmotekandidatEndring.uuid shouldBeEqualTo dialogmoteKandidatEndring.uuid
-                insertedDialogmotekandidatEndring.arsak shouldBeEqualTo dialogmoteKandidatEndring.arsak
-                insertedDialogmotekandidatEndring.kandidat shouldBeEqualTo dialogmoteKandidatEndring.kandidat
+                insertedDialogmotekandidatEndring?.personIdent shouldBeEqualTo dialogmoteKandidatEndring.personIdentNumber
+                insertedDialogmotekandidatEndring?.uuid shouldBeEqualTo dialogmoteKandidatEndring.uuid
+                insertedDialogmotekandidatEndring?.arsak shouldBeEqualTo dialogmoteKandidatEndring.arsak.toString()
+                insertedDialogmotekandidatEndring?.kandidat shouldBeEqualTo dialogmoteKandidatEndring.kandidat
             }
         }
     }

--- a/src/test/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmotekandidat/database/DialogmotekandidatRepositorySpek.kt
@@ -1,0 +1,40 @@
+package no.nav.syfo.dialogmotekandidat.database
+
+import io.ktor.server.testing.*
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.dropData
+import no.nav.syfo.testhelper.generator.generateDialogmotekandidatEndringStoppunkt
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class DialogmotekandidatRepositorySpek : Spek({
+
+    val kandidatPersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER
+
+    describe(DialogmotekandidatRepositorySpek::class.java.simpleName) {
+        with(TestApplicationEngine()) {
+            start()
+            val externalMockEnvironment = ExternalMockEnvironment.instance
+            val database = externalMockEnvironment.database
+            val dialogmotekandidatRepository = DialogmotekandidatRepository(database)
+
+            afterEachTest {
+                database.dropData()
+            }
+
+            describe("Successfully gets a dialogmotekandidatendring") {
+                val dialogmoteKandidatEndring = generateDialogmotekandidatEndringStoppunkt(kandidatPersonIdent)
+                database.connection.createDialogmotekandidatEndring(dialogmotekandidatEndring = dialogmoteKandidatEndring)
+
+                val insertedDialogmotekandidatEndring =
+                    dialogmotekandidatRepository.getDialogmotekandidatEndring(dialogmoteKandidatEndring.uuid)
+                insertedDialogmotekandidatEndring.personIdent shouldBeEqualTo dialogmoteKandidatEndring.personIdentNumber
+                insertedDialogmotekandidatEndring.uuid shouldBeEqualTo dialogmoteKandidatEndring.uuid
+                insertedDialogmotekandidatEndring.arsak shouldBeEqualTo dialogmoteKandidatEndring.arsak
+                insertedDialogmotekandidatEndring.kandidat shouldBeEqualTo dialogmoteKandidatEndring.kandidat
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/dialogmotestatusendring/kafka/KafkaDialogmoteStatusEndringServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/dialogmotestatusendring/kafka/KafkaDialogmoteStatusEndringServiceSpek.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.oppfolgingstilfelle.OppfolgingstilfelleClient
 import no.nav.syfo.dialogmote.avro.KDialogmoteStatusEndring
 import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
+import no.nav.syfo.dialogmotekandidat.database.DialogmotekandidatRepository
 import no.nav.syfo.dialogmotekandidat.database.getDialogmotekandidatEndringListForPerson
 import no.nav.syfo.dialogmotekandidat.domain.DialogmotekandidatEndringArsak
 import no.nav.syfo.dialogmotekandidat.kafka.DialogmotekandidatEndringProducer
@@ -53,6 +54,7 @@ class KafkaDialogmoteStatusEndringServiceSpek : Spek({
             oppfolgingstilfelleService = oppfolgingstilfelleService,
             dialogmotekandidatEndringProducer = dialogmotekandidatEndringProducer,
             database = database,
+            dialogmotekandidatRepository = DialogmotekandidatRepository(database),
         )
 
         val kafkaDialogmoteStatusEndringService = KafkaDialogmoteStatusEndringService(
@@ -159,9 +161,10 @@ class KafkaDialogmoteStatusEndringServiceSpek : Spek({
                         kafkaProducer.send(capture(producerRecordSlot))
                     }
 
-                    val latestDialogmoteFerdigstiltTidspunkt = database.connection.getLatestDialogmoteFerdigstiltForPerson(
-                        personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
-                    )
+                    val latestDialogmoteFerdigstiltTidspunkt =
+                        database.connection.getLatestDialogmoteFerdigstiltForPerson(
+                            personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
+                        )
                     latestDialogmoteFerdigstiltTidspunkt!!.toLocalDate() shouldBeEqualTo statusEndringTidspunkt.toLocalDate()
 
                     val latestDialogmotekandidatEndring =
@@ -192,9 +195,10 @@ class KafkaDialogmoteStatusEndringServiceSpek : Spek({
                         kafkaProducer.send(any())
                     }
 
-                    val latestDialogmoteFerdigstiltTidspunkt = database.connection.getLatestDialogmoteFerdigstiltForPerson(
-                        personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
-                    )
+                    val latestDialogmoteFerdigstiltTidspunkt =
+                        database.connection.getLatestDialogmoteFerdigstiltForPerson(
+                            personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
+                        )
                     latestDialogmoteFerdigstiltTidspunkt!!.toLocalDate() shouldBeEqualTo statusEndringTidspunkt.toLocalDate()
 
                     val latestDialogmotekandidatEndring =
@@ -215,9 +219,10 @@ class KafkaDialogmoteStatusEndringServiceSpek : Spek({
                     verify(exactly = 0) {
                         kafkaProducer.send(any())
                     }
-                    val latestDialogmoteFerdigstiltTidspunkt = database.connection.getLatestDialogmoteFerdigstiltForPerson(
-                        personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
-                    )
+                    val latestDialogmoteFerdigstiltTidspunkt =
+                        database.connection.getLatestDialogmoteFerdigstiltForPerson(
+                            personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
+                        )
                     latestDialogmoteFerdigstiltTidspunkt!!.toLocalDate() shouldBeEqualTo statusEndringTidspunkt.toLocalDate()
                 }
             }
@@ -245,9 +250,10 @@ class KafkaDialogmoteStatusEndringServiceSpek : Spek({
                     verify(exactly = 0) {
                         kafkaProducer.send(any())
                     }
-                    val latestDialogmoteFerdigstiltTidspunkt = database.connection.getLatestDialogmoteFerdigstiltForPerson(
-                        personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
-                    )
+                    val latestDialogmoteFerdigstiltTidspunkt =
+                        database.connection.getLatestDialogmoteFerdigstiltForPerson(
+                            personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
+                        )
                     latestDialogmoteFerdigstiltTidspunkt shouldBe null
                 }
                 it("creates no new DialogmotekandidatEndring when latest endring for person is kandidat and created after innkalt") {
@@ -263,9 +269,10 @@ class KafkaDialogmoteStatusEndringServiceSpek : Spek({
                     verify(exactly = 0) {
                         kafkaProducer.send(any())
                     }
-                    val latestDialogmoteFerdigstiltTidspunkt = database.connection.getLatestDialogmoteFerdigstiltForPerson(
-                        personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
-                    )
+                    val latestDialogmoteFerdigstiltTidspunkt =
+                        database.connection.getLatestDialogmoteFerdigstiltForPerson(
+                            personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
+                        )
                     latestDialogmoteFerdigstiltTidspunkt shouldBe null
                 }
                 it("creates no new DialogmotekandidatEndring when no latest endring for person") {
@@ -279,9 +286,10 @@ class KafkaDialogmoteStatusEndringServiceSpek : Spek({
                     verify(exactly = 0) {
                         kafkaProducer.send(any())
                     }
-                    val latestDialogmoteFerdigstiltTidspunkt = database.connection.getLatestDialogmoteFerdigstiltForPerson(
-                        personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
-                    )
+                    val latestDialogmoteFerdigstiltTidspunkt =
+                        database.connection.getLatestDialogmoteFerdigstiltForPerson(
+                            personIdent = ARBEIDSTAKER_PERSONIDENTNUMBER,
+                        )
                     latestDialogmoteFerdigstiltTidspunkt shouldBe null
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.oppfolgingstilfelle.OppfolgingstilfelleClient
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.dialogmotekandidat.DialogmotekandidatService
+import no.nav.syfo.dialogmotekandidat.database.DialogmotekandidatRepository
 import no.nav.syfo.dialogmotekandidat.kafka.DialogmotekandidatEndringProducer
 import no.nav.syfo.oppfolgingstilfelle.OppfolgingstilfelleService
 
@@ -29,6 +30,7 @@ fun Application.testApiModule(
         oppfolgingstilfelleService = oppfolgingstilfelleService,
         dialogmotekandidatEndringProducer = dialogmotekandidatEndringProducer,
         database = externalMockEnvironment.database,
+        dialogmotekandidatRepository = DialogmotekandidatRepository(externalMockEnvironment.database),
     )
     this.apiModule(
         applicationState = externalMockEnvironment.applicationState,


### PR DESCRIPTION
- Legger til uuid som skal slettes
- Fantes ikke funksjon som hentet ut fra database basert på `UUID` så måtte legge til dette. Tenkte det var dumt å fortsette på query mønsteret, så la til ny repository fil som kan være utgangspunkt for videre refaktorering.

Todos etter merge
- Sjekk at `syfooversiktsrv` database blir oppdatert