### PR TITLE
Fix versions and dependabot, simplify build config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,12 @@ updates:
   - package-ecosystem: gradle
     directory: "/"
     schedule:
-      interval: daily
-      time: "07:00"
+      interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/README.md
+++ b/README.md
@@ -19,44 +19,8 @@
 
 #### Requirements
 
-* JDK 11
+* JDK 21
 
-## Download packages from Github Package Registry
-
-Certain packages (isdialogmote-schema) must be downloaded from Github Package Registry, which requires
-authentication. The packages can be downloaded via build.gradle:
-
-```
-val githubUser: String by project
-val githubPassword: String by project
-repositories {
-    maven {
-        url = uri("https://maven.pkg.github.com/navikt/isdialogmote-schema")
-        credentials {
-            username = githubUser
-            password = githubPassword
-        }
-    }
-}
-```
-
-`githubUser` and `githubPassword` are properties that are set in `~/.gradle/gradle.properties`:
-
-```
-githubUser=x-access-token
-githubPassword=<token>
-```
-
-Where `<token>` is a personal access token with scope `read:packages`(and SSO enabled).
-
-The variables can alternatively be configured as environment variables or used in the command lines:
-
-* `ORG_GRADLE_PROJECT_githubUser`
-* `ORG_GRADLE_PROJECT_githubPassword`
-
-```
-./gradlew -PgithubUser=x-access-token -PgithubPassword=[token]
-```
 
 ### Build
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,47 +1,37 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import org.apache.tools.ant.taskdefs.condition.Os
-
 group = "no.nav.syfo"
 version = "0.0.1"
 
-object Versions {
-    const val confluent = "7.5.1"
-    const val flyway = "9.22.3"
-    const val hikari = "5.1.0"
-    const val isdialogmoteSchema = "1.0.5"
-    const val jacksonDataType = "2.16.1"
-    const val jetty = "9.4.54.v20240208"
-    const val kafka = "3.6.1"
-    const val kluent = "1.73"
-    const val ktor = "2.3.8"
-    const val logback = "1.4.14"
-    const val logstashEncoder = "7.4"
-    const val micrometerRegistry = "1.12.2"
-    const val nimbusJoseJwt = "9.37.3"
-    const val mockk = "1.13.9"
-    const val postgres = "42.7.2"
-    val postgresEmbedded = if (Os.isFamily(Os.FAMILY_MAC)) "1.0.0" else "0.13.4"
-    const val scala = "2.13.12"
-    const val spek = "2.0.19"
-}
+val confluentVersion = "7.5.1"
+val flywayVersion = "9.22.3"
+val hikariVersion = "5.1.0"
+val isdialogmoteSchemaVersion = "1.0.5"
+val jacksonDataTypeVersion = "2.16.1"
+val jettyVersion = "9.4.54.v20240208"
+val kafkaVersion = "3.6.1"
+val kluentVersion = "1.73"
+val ktorVersion = "2.3.8"
+val logbackVersion = "1.4.14"
+val logstashEncoderVersion = "7.4"
+val micrometerRegistryVersion = "1.12.2"
+val nimbusJoseJwtVersion = "9.37.3"
+val mockkVersion = "1.13.9"
+val postgresVersion = "42.7.2"
+val postgresEmbeddedVersion = "2.0.7"
+val scalaVersion = "2.13.12"
+val spekVersion = "2.0.19"
+
 plugins {
-    kotlin("jvm") version "2.0.10"
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    kotlin("jvm") version "2.0.20"
+    id("com.gradleup.shadow") version "8.3.0"
     id("org.jlleitschuh.gradle.ktlint") version "11.6.0"
 }
 
-val githubUser: String by project
-val githubPassword: String by project
 repositories {
     mavenCentral()
     maven(url = "https://packages.confluent.io/maven/")
     maven(url = "https://jitpack.io")
     maven {
-        url = uri("https://maven.pkg.github.com/navikt/isdialogmote-schema")
-        credentials {
-            username = githubUser
-            password = githubPassword
-        }
+        url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
     }
 }
 
@@ -49,56 +39,56 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation(kotlin("reflect"))
 
-    implementation("io.ktor:ktor-serialization-jackson:${Versions.ktor}")
-    implementation("io.ktor:ktor-client-cio:${Versions.ktor}")
-    implementation("io.ktor:ktor-client-apache:${Versions.ktor}")
-    implementation("io.ktor:ktor-client-content-negotiation:${Versions.ktor}")
-    implementation("io.ktor:ktor-server-auth-jwt:${Versions.ktor}")
-    implementation("io.ktor:ktor-server-call-id:${Versions.ktor}")
-    implementation("io.ktor:ktor-server-content-negotiation:${Versions.ktor}")
-    implementation("io.ktor:ktor-server-netty:${Versions.ktor}")
-    implementation("io.ktor:ktor-server-status-pages:${Versions.ktor}")
+    implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio:$ktorVersion")
+    implementation("io.ktor:ktor-client-apache:$ktorVersion")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+    implementation("io.ktor:ktor-server-auth-jwt:$ktorVersion")
+    implementation("io.ktor:ktor-server-call-id:$ktorVersion")
+    implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
+    implementation("io.ktor:ktor-server-netty:$ktorVersion")
+    implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
 
     // Logging
-    implementation("ch.qos.logback:logback-classic:${Versions.logback}")
-    implementation("net.logstash.logback:logstash-logback-encoder:${Versions.logstashEncoder}")
+    implementation("ch.qos.logback:logback-classic:$logbackVersion")
+    implementation("net.logstash.logback:logstash-logback-encoder:$logstashEncoderVersion")
 
     // Metrics and Prometheus
-    implementation("io.ktor:ktor-server-metrics-micrometer:${Versions.ktor}")
-    implementation("io.micrometer:micrometer-registry-prometheus:${Versions.micrometerRegistry}")
+    implementation("io.ktor:ktor-server-metrics-micrometer:$ktorVersion")
+    implementation("io.micrometer:micrometer-registry-prometheus:$micrometerRegistryVersion")
 
     // (De-)serialization
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${Versions.jacksonDataType}")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion")
 
     // Database
-    implementation("org.postgresql:postgresql:${Versions.postgres}")
-    implementation("com.zaxxer:HikariCP:${Versions.hikari}")
-    implementation("org.flywaydb:flyway-core:${Versions.flyway}")
-    testImplementation("com.opentable.components:otj-pg-embedded:${Versions.postgresEmbedded}")
+    implementation("org.postgresql:postgresql:$postgresVersion")
+    implementation("com.zaxxer:HikariCP:$hikariVersion")
+    implementation("org.flywaydb:flyway-core:$flywayVersion")
+    testImplementation("io.zonky.test:embedded-postgres:$postgresEmbeddedVersion")
 
     // Kafka
     val excludeLog4j = fun ExternalModuleDependency.() {
         exclude(group = "log4j")
     }
-    implementation("org.apache.kafka:kafka_2.13:${Versions.kafka}", excludeLog4j)
+    implementation("org.apache.kafka:kafka_2.13:$kafkaVersion", excludeLog4j)
     constraints {
         implementation("org.apache.zookeeper:zookeeper") {
-            because("org.apache.kafka:kafka_2.13:${Versions.kafka} -> https://www.cve.org/CVERecord?id=CVE-2023-44981")
+            because("org.apache.kafka:kafka_2.13:$kafkaVersion -> https://www.cve.org/CVERecord?id=CVE-2023-44981")
             version {
                 require("3.8.3")
             }
         }
         implementation("org.scala-lang:scala-library") {
-            because("org.apache.kafka:kafka_2.13:${Versions.kafka} -> https://www.cve.org/CVERecord?id=CVE-2022-36944")
+            because("org.apache.kafka:kafka_2.13:$kafkaVersion -> https://www.cve.org/CVERecord?id=CVE-2022-36944")
             version {
-                require(Versions.scala)
+                require(scalaVersion)
             }
         }
     }
-    implementation("io.confluent:kafka-avro-serializer:${Versions.confluent}", excludeLog4j)
+    implementation("io.confluent:kafka-avro-serializer:$confluentVersion", excludeLog4j)
     constraints {
         implementation("org.apache.avro:avro") {
-            because("io.confluent:kafka-avro-serializer:${Versions.confluent} -> https://www.cve.org/CVERecord?id=CVE-2023-39410")
+            because("io.confluent:kafka-avro-serializer:$confluentVersion -> https://www.cve.org/CVERecord?id=CVE-2023-39410")
             version {
                 require("1.11.3")
             }
@@ -110,48 +100,48 @@ dependencies {
             }
         }
     }
-    implementation("io.confluent:kafka-schema-registry:${Versions.confluent}", excludeLog4j)
+    implementation("io.confluent:kafka-schema-registry:$confluentVersion", excludeLog4j)
     constraints {
         implementation("org.json:json") {
-            because("io.confluent:kafka-schema-registry:${Versions.confluent} -> https://www.cve.org/CVERecord?id=CVE-2023-5072")
+            because("io.confluent:kafka-schema-registry:$confluentVersion -> https://www.cve.org/CVERecord?id=CVE-2023-5072")
             version {
                 require("20231013")
             }
         }
         implementation("org.eclipse.jetty:jetty-server") {
-            because("io.confluent:kafka-schema-registry:${Versions.confluent} -> https://www.cve.org/CVERecord?id=CVE-2023-36478")
+            because("io.confluent:kafka-schema-registry:$confluentVersion -> https://www.cve.org/CVERecord?id=CVE-2023-36478")
             version {
-                require(Versions.jetty)
+                require(jettyVersion)
             }
         }
         implementation("org.eclipse.jetty:jetty-xml") {
-            because("io.confluent:kafka-schema-registry:${Versions.confluent} -> https://www.cve.org/CVERecord?id=CVE-2023-36478")
+            because("io.confluent:kafka-schema-registry:$confluentVersion -> https://www.cve.org/CVERecord?id=CVE-2023-36478")
             version {
-                require(Versions.jetty)
+                require(jettyVersion)
             }
         }
         implementation("org.eclipse.jetty:jetty-servlets") {
-            because("io.confluent:kafka-schema-registry:${Versions.confluent} -> https://www.cve.org/CVERecord?id=CVE-2023-36478")
+            because("io.confluent:kafka-schema-registry:$confluentVersion -> https://www.cve.org/CVERecord?id=CVE-2023-36478")
             version {
-                require(Versions.jetty)
+                require(jettyVersion)
             }
         }
         implementation("org.eclipse.jetty.http2:http2-server") {
-            because("io.confluent:kafka-schema-registry:${Versions.confluent} -> https://www.cve.org/CVERecord?id=CVE-2023-36478")
+            because("io.confluent:kafka-schema-registry:$confluentVersion -> https://www.cve.org/CVERecord?id=CVE-2023-36478")
             version {
-                require(Versions.jetty)
+                require(jettyVersion)
             }
         }
     }
-    implementation("no.nav.syfo.dialogmote.avro:isdialogmote-schema:${Versions.isdialogmoteSchema}")
+    implementation("no.nav.syfo.dialogmote.avro:isdialogmote-schema:$isdialogmoteSchemaVersion")
 
-    testImplementation("com.nimbusds:nimbus-jose-jwt:${Versions.nimbusJoseJwt}")
-    testImplementation("io.ktor:ktor-server-tests:${Versions.ktor}")
-    testImplementation("io.ktor:ktor-client-mock:${Versions.ktor}")
-    testImplementation("io.mockk:mockk:${Versions.mockk}")
-    testImplementation("org.amshove.kluent:kluent:${Versions.kluent}")
-    testImplementation("org.spekframework.spek2:spek-dsl-jvm:${Versions.spek}")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:${Versions.spek}")
+    testImplementation("com.nimbusds:nimbus-jose-jwt:$nimbusJoseJwtVersion")
+    testImplementation("io.ktor:ktor-server-tests:$ktorVersion")
+    testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
+    testImplementation("io.mockk:mockk:$mockkVersion")
+    testImplementation("org.amshove.kluent:kluent:$kluentVersion")
+    testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
+    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 }
 
 kotlin {
@@ -159,7 +149,7 @@ kotlin {
 }
 
 tasks {
-    withType<Jar> {
+    jar {
         manifest.attributes["Main-Class"] = "no.nav.syfo.AppKt"
     }
 
@@ -169,13 +159,13 @@ tasks {
         }
     }
 
-    withType<ShadowJar> {
+    shadowJar {
         archiveBaseName.set("app")
         archiveClassifier.set("")
         archiveVersion.set("")
     }
 
-    withType<Test> {
+    test {
         useJUnitPlatform {
             includeEngines("spek2")
         }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.testhelper
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.dialogmotekandidat.database.createDialogmotekandidatEndring
 import no.nav.syfo.dialogmotekandidat.database.getDialogmotekandidatEndringListForPerson


### PR DESCRIPTION
Sånn at dependabot finner avhengigheter og lagrer ukentige PRs på oppdateringer. Grupperer minor og patch-oppdatering i samme PR.
Gjorde også forenkling av bygge-config inspirert av https://github.com/navikt/isdialogmote/