### PR TITLE
IS-2872: Sender unike personidenter til tilgangskontroll

### DIFF
--- a/src/main/kotlin/no/nav/syfo/unntak/UnntakService.kt
+++ b/src/main/kotlin/no/nav/syfo/unntak/UnntakService.kt
@@ -64,6 +64,10 @@ class UnntakService(
         token: String,
         callId: String,
     ): List<UnntakStatistikk> {
+        if (unntakList.isEmpty()) {
+            return emptyList()
+        }
+
         val starttime = System.currentTimeMillis()
         val oppfolgingstilfelleForUnntak = getOppfolgingstilfelleForUnntak(
             unntakList = unntakList,

--- a/src/main/kotlin/no/nav/syfo/unntak/api/UnntakApi.kt
+++ b/src/main/kotlin/no/nav/syfo/unntak/api/UnntakApi.kt
@@ -65,20 +65,24 @@ fun Route.registerUnntakApi(
 
             val unntakForventetFriskmelding = unntakService.getUnntakForVeileder(veilderIdent = veilderIdent)
                 .filter { unntak -> unntak.arsak == UnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER }
-            val personListWithVeilederAccess = veilederTilgangskontrollClient.hasAccessToPersonList(
-                personIdentList = unntakForventetFriskmelding.map { it.personIdent }.distinct(),
-                token = token,
-                callId = callId,
-            )
-            val unntakForventetFriskmeldingWithVeilederAccess =
-                unntakForventetFriskmelding.filter { unntak -> personListWithVeilederAccess.contains(unntak.personIdent) }
+            if (unntakForventetFriskmelding.isNotEmpty()) {
+                val personListWithVeilederAccess = veilederTilgangskontrollClient.hasAccessToPersonList(
+                    personIdentList = unntakForventetFriskmelding.map { it.personIdent }.distinct(),
+                    token = token,
+                    callId = callId,
+                )
+                val unntakForventetFriskmeldingWithVeilederAccess =
+                    unntakForventetFriskmelding.filter { unntak -> personListWithVeilederAccess.contains(unntak.personIdent) }
 
-            val unntakStatistikkList = unntakService.getUnntakStatistikk(
-                unntakList = unntakForventetFriskmeldingWithVeilederAccess,
-                token = token,
-                callId = callId,
-            )
-            call.respond(unntakStatistikkList)
+                val unntakStatistikkList = unntakService.getUnntakStatistikk(
+                    unntakList = unntakForventetFriskmeldingWithVeilederAccess,
+                    token = token,
+                    callId = callId,
+                )
+                call.respond(unntakStatistikkList)
+            } else {
+                call.respond(emptyList<UnntakStatistikk>())
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/unntak/api/UnntakApi.kt
+++ b/src/main/kotlin/no/nav/syfo/unntak/api/UnntakApi.kt
@@ -66,7 +66,7 @@ fun Route.registerUnntakApi(
             val unntakForventetFriskmelding = unntakService.getUnntakForVeileder(veilderIdent = veilderIdent)
                 .filter { unntak -> unntak.arsak == UnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER }
             val personListWithVeilederAccess = veilederTilgangskontrollClient.hasAccessToPersonList(
-                personIdentList = unntakForventetFriskmelding.map { it.personIdent },
+                personIdentList = unntakForventetFriskmelding.map { it.personIdent }.distinct(),
                 token = token,
                 callId = callId,
             )


### PR DESCRIPTION
Kom over en liten forbedring ifm feilsøking av https://trello.com/c/fdQcI5DN/2872-channelwriteexception-i-isoppfolgingstilfelle
Her sender vi potensielt unødvendige duplikater til tilgangskontrollen.