### PR TITLE
IS-2884: Add ikke aktuell-arsaker

### DIFF
--- a/src/main/kotlin/no/nav/syfo/ikkeaktuell/domain/IkkeAktuell.kt
+++ b/src/main/kotlin/no/nav/syfo/ikkeaktuell/domain/IkkeAktuell.kt
@@ -8,6 +8,8 @@ enum class IkkeAktuellArsak {
     ARBEIDSTAKER_AAP,
     ARBEIDSTAKER_DOD,
     DIALOGMOTE_AVHOLDT,
+    FRISKMELDT,
+    ARBEIDSFORHOLD_OPPHORT,
 }
 
 data class IkkeAktuell(


### PR DESCRIPTION
Legger til rette for at disse årsakene skal brukes når det registreres "ikke aktuell" i stedet for "unntak" for dialogmøtekandidat.
Når frontend er tilpasset bør vi gjøre slik at disse årsakene ikke tillates for nye unntak (men vi må beholde de i koden for å kunne hente opp gamle unntak i apiet)