### PR TITLE
IS-3258: Use correct postgres version in tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ val nimbusJoseJwtVersion = "10.3"
 val mockkVersion = "1.14.4"
 val postgresVersion = "42.7.7"
 val postgresEmbeddedVersion = "2.1.0"
+val postgresRuntimeVersion = "17.5.0"
 val spekVersion = "2.0.19"
 
 plugins {
@@ -67,6 +68,7 @@ dependencies {
     implementation("com.zaxxer:HikariCP:$hikariVersion")
     implementation("org.flywaydb:flyway-database-postgresql:$flywayVersion")
     testImplementation("io.zonky.test:embedded-postgres:$postgresEmbeddedVersion")
+    testImplementation(platform("io.zonky.test.postgres:embedded-postgres-binaries-bom:$postgresRuntimeVersion"))
 
     // Kafka
     val excludeLog4j = fun ExternalModuleDependency.() {


### PR DESCRIPTION
Hvis jeg leser dokumentasjonen riktig er det dette som trengs: 
https://github.com/zonkyio/embedded-postgres

Postgres 17.5 er den versjonen vi faktisk bruker på GCP/CloudSQL nå (for alle backend'ene våre).