### PR TITLE
IS-3060: Add endpoint to get ikkeaktuell vurdering

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/CreateIkkeAktuellDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/CreateIkkeAktuellDTO.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.api
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.IkkeAktuell
 import no.nav.syfo.domain.IkkeAktuellArsak
 import no.nav.syfo.util.nowUTC
@@ -18,7 +18,7 @@ fun CreateIkkeAktuellDTO.toIkkeAktuell(
     uuid = UUID.randomUUID(),
     createdAt = nowUTC(),
     createdBy = createdByIdent,
-    personIdent = PersonIdentNumber(this.personIdent),
+    personIdent = Personident(this.personIdent),
     arsak = IkkeAktuellArsak.valueOf(this.arsak),
     beskrivelse = this.beskrivelse,
 )

--- a/src/main/kotlin/no/nav/syfo/api/CreateUnntakDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/CreateUnntakDTO.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.api
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Unntak
 import no.nav.syfo.domain.UnntakArsak
 
@@ -14,7 +14,7 @@ fun CreateUnntakDTO.toUnntak(
     createdByIdent: String,
 ) = Unntak(
     createdBy = createdByIdent,
-    personIdent = PersonIdentNumber(this.personIdent),
+    personIdent = Personident(this.personIdent),
     arsak = UnntakArsak.valueOf(this.arsak),
     beskrivelse = this.beskrivelse,
 )

--- a/src/main/kotlin/no/nav/syfo/api/HistorikkDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/HistorikkDTO.kt
@@ -28,19 +28,21 @@ data class HistorikkDTO(
 fun List<DialogmotekandidatEndring>.toKandidatHistorikk(): List<HistorikkDTO> = this.mapNotNull {
     val tidspunkt = it.createdAt.toLocalDateTime()
     when (it.arsak) {
-        DialogmotekandidatEndringArsak.STOPPUNKT -> HistorikkDTO(
-            tidspunkt = tidspunkt,
-            type = HistorikkType.KANDIDAT,
-            arsak = it.arsak.name,
-            vurdertAv = null,
-        )
+        DialogmotekandidatEndringArsak.STOPPUNKT ->
+            HistorikkDTO(
+                tidspunkt = tidspunkt,
+                type = HistorikkType.KANDIDAT,
+                arsak = it.arsak.name,
+                vurdertAv = null,
+            )
 
-        DialogmotekandidatEndringArsak.LUKKET -> HistorikkDTO(
-            tidspunkt = tidspunkt,
-            type = HistorikkType.LUKKET,
-            arsak = it.arsak.name,
-            vurdertAv = null,
-        )
+        DialogmotekandidatEndringArsak.LUKKET ->
+            HistorikkDTO(
+                tidspunkt = tidspunkt,
+                type = HistorikkType.LUKKET,
+                arsak = it.arsak.name,
+                vurdertAv = null,
+            )
 
         // Disse dekkes av dialogmote-historikk og unntak/ikke-aktuell-historikk
         DialogmotekandidatEndringArsak.DIALOGMOTE_FERDIGSTILT, DialogmotekandidatEndringArsak.DIALOGMOTE_LUKKET, DialogmotekandidatEndringArsak.UNNTAK, DialogmotekandidatEndringArsak.IKKE_AKTUELL -> null

--- a/src/main/kotlin/no/nav/syfo/api/endpoints/DialogmotekandidatApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/DialogmotekandidatApi.kt
@@ -7,7 +7,7 @@ import no.nav.syfo.api.HistorikkDTO
 import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.application.DialogmotekandidatService
 import no.nav.syfo.domain.toDialogmotekandidatDTO
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.application.IkkeAktuellService
 import no.nav.syfo.application.OppfolgingstilfelleService
 import no.nav.syfo.application.UnntakService
@@ -28,7 +28,7 @@ fun Route.registerDialogmotekandidatApi(
     route(kandidatApiBasePath) {
         get(kandidatApiPersonidentPath) {
             val personIdent = personIdentHeader()?.let { personIdent ->
-                PersonIdentNumber(personIdent)
+                Personident(personIdent)
             }
                 ?: throw IllegalArgumentException("Failed to get kandidat for person: No $NAV_PERSONIDENT_HEADER supplied in request header")
             validateVeilederAccess(
@@ -63,7 +63,7 @@ fun Route.registerDialogmotekandidatApi(
         }
         get(kandidatApiHistorikkPath) {
             val personident = personIdentHeader()?.let { personIdent ->
-                PersonIdentNumber(personIdent)
+                Personident(personIdent)
             }
                 ?: throw IllegalArgumentException("Failed to get historikk for person: No $NAV_PERSONIDENT_HEADER supplied in request header")
             validateVeilederAccess(

--- a/src/main/kotlin/no/nav/syfo/api/endpoints/IkkeAktuellApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/IkkeAktuellApi.kt
@@ -6,22 +6,21 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.api.CreateIkkeAktuellDTO
 import no.nav.syfo.api.toIkkeAktuell
-import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
-import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.application.IkkeAktuellService
+import no.nav.syfo.domain.Personident
+import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.util.*
 
 const val ikkeAktuellApiBasePath = "/api/internad/v1/ikkeaktuell"
-const val ikkeAktuellApiPersonidentPath = "/personident"
 
 fun Route.registerIkkeAktuellApi(
     veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
     ikkeAktuellService: IkkeAktuellService,
 ) {
     route(ikkeAktuellApiBasePath) {
-        post(ikkeAktuellApiPersonidentPath) {
+        post("/personident") {
             val createIkkeAktuellDTO = call.receive<CreateIkkeAktuellDTO>()
-            val personIdent = PersonIdentNumber(createIkkeAktuellDTO.personIdent)
+            val personIdent = Personident(createIkkeAktuellDTO.personIdent)
             validateVeilederAccess(
                 action = "Create ikke-aktuell for person",
                 personIdentToAccess = personIdent,
@@ -37,6 +36,19 @@ fun Route.registerIkkeAktuellApi(
                 )
 
                 call.respond(HttpStatusCode.Created)
+            }
+        }
+        get("/personident") {
+            val personIdent = personIdentHeader()?.let { Personident(it) }
+                ?: throw IllegalArgumentException("Failed to get ikke-aktuell for person: No $NAV_PERSONIDENT_HEADER supplied in request header")
+            validateVeilederAccess(
+                action = "Get ikke-aktuell for person",
+                personIdentToAccess = personIdent,
+                veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+            ) {
+                call.respond(
+                    ikkeAktuellService.getIkkeAktuellList(personIdent = personIdent)
+                )
             }
         }
     }

--- a/src/main/kotlin/no/nav/syfo/api/endpoints/UnntakApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/UnntakApi.kt
@@ -8,7 +8,7 @@ import no.nav.syfo.api.CreateUnntakDTO
 import no.nav.syfo.api.toUnntak
 import no.nav.syfo.api.toUnntakDTOList
 import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.application.UnntakService
 import no.nav.syfo.util.*
 
@@ -22,7 +22,7 @@ fun Route.registerUnntakApi(
     route(unntakApiBasePath) {
         post(unntakApiPersonidentPath) {
             val createUnntakDTO = call.receive<CreateUnntakDTO>()
-            val personIdent = PersonIdentNumber(createUnntakDTO.personIdent)
+            val personIdent = Personident(createUnntakDTO.personIdent)
             validateVeilederAccess(
                 action = "Create unntak for person",
                 personIdentToAccess = personIdent,
@@ -42,7 +42,7 @@ fun Route.registerUnntakApi(
         }
         get(unntakApiPersonidentPath) {
             val personIdent = personIdentHeader()?.let { personIdent ->
-                PersonIdentNumber(personIdent)
+                Personident(personIdent)
             }
                 ?: throw IllegalArgumentException("Failed to get unntak for person: No $NAV_PERSONIDENT_HEADER supplied in request header")
             validateVeilederAccess(

--- a/src/main/kotlin/no/nav/syfo/application/DialogmotekandidatService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/DialogmotekandidatService.kt
@@ -8,7 +8,7 @@ import no.nav.syfo.infrastructure.database.getLatestDialogmoteFerdigstiltForPers
 import no.nav.syfo.domain.DialogmotekandidatEndring
 import no.nav.syfo.domain.DialogmotekandidatStoppunkt
 import no.nav.syfo.domain.DialogmotekandidatStoppunktStatus
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Unntak
 import no.nav.syfo.domain.isDialogmotekandidat
 import no.nav.syfo.domain.toDialogmotekandidatEndring
@@ -34,11 +34,11 @@ class DialogmotekandidatService(
     private val dialogmotekandidatRepository: DialogmotekandidatRepository,
 ) {
     fun getLatestDialogmotekandidatEndring(
-        personIdent: PersonIdentNumber,
+        personIdent: Personident,
     ) = getDialogmotekandidatEndringer(personIdent = personIdent).firstOrNull()
 
     fun getDialogmotekandidatEndringer(
-        personIdent: PersonIdentNumber,
+        personIdent: Personident,
     ) = database.connection.use { connection ->
         connection.getDialogmotekandidatEndringListForPerson(personIdent = personIdent)
     }.toDialogmotekandidatEndringList()

--- a/src/main/kotlin/no/nav/syfo/application/IIkkeAktuellRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IIkkeAktuellRepository.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.application
+
+import no.nav.syfo.domain.IkkeAktuell
+import no.nav.syfo.domain.Personident
+import no.nav.syfo.infrastructure.database.PIkkeAktuell
+import java.sql.Connection
+
+interface IIkkeAktuellRepository {
+    suspend fun getIkkeAktuellListForPerson(personIdent: Personident): List<PIkkeAktuell>
+    suspend fun createIkkeAktuell(connection: Connection, commit: Boolean, ikkeAktuell: IkkeAktuell): Unit
+}

--- a/src/main/kotlin/no/nav/syfo/application/IdenthendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IdenthendelseService.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.application
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.infrastructure.database.DatabaseInterface
 import no.nav.syfo.infrastructure.clients.pdl.PdlClient
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.infrastructure.kafka.identhendelse.COUNT_KAFKA_CONSUMER_PDL_AKTOR_UPDATES
 import no.nav.syfo.infrastructure.kafka.identhendelse.KafkaIdenthendelseDTO
 import no.nav.syfo.infrastructure.database.getIdentCount
@@ -37,7 +37,7 @@ class IdenthendelseService(
         }
     }
 
-    private fun updateAllTables(activeIdent: PersonIdentNumber, inactiveIdenter: List<PersonIdentNumber>): Int {
+    private fun updateAllTables(activeIdent: Personident, inactiveIdenter: List<Personident>): Int {
         var numberOfUpdatedIdenter = 0
         val inactiveIdenterCount = database.getIdentCount(inactiveIdenter)
 
@@ -56,7 +56,7 @@ class IdenthendelseService(
     }
 
     // Erfaringer fra andre team tilsier at vi burde dobbeltsjekke at ting har blitt oppdatert i PDL før vi gjør endringer
-    private fun checkThatPdlIsUpdated(nyIdent: PersonIdentNumber) {
+    private fun checkThatPdlIsUpdated(nyIdent: Personident) {
         runBlocking {
             val pdlIdenter = pdlClient.getPdlIdenter(nyIdent)?.hentIdenter ?: throw RuntimeException("Fant ingen identer fra PDL")
             if (nyIdent.value != pdlIdenter.aktivIdent && pdlIdenter.identhendelseIsNotHistorisk(nyIdent.value)) {

--- a/src/main/kotlin/no/nav/syfo/application/IkkeAktuellService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IkkeAktuellService.kt
@@ -1,21 +1,19 @@
 package no.nav.syfo.application
 
-import no.nav.syfo.infrastructure.database.DatabaseInterface
 import no.nav.syfo.api.exception.ConflictException
+import no.nav.syfo.domain.DialogmotekandidatEndring
+import no.nav.syfo.domain.IkkeAktuell
+import no.nav.syfo.domain.Personident
+import no.nav.syfo.domain.isLatestIkkeKandidat
+import no.nav.syfo.infrastructure.database.DatabaseInterface
 import no.nav.syfo.infrastructure.database.dialogmotekandidat.getDialogmotekandidatEndringListForPerson
 import no.nav.syfo.infrastructure.database.dialogmotekandidat.toDialogmotekandidatEndringList
-import no.nav.syfo.domain.DialogmotekandidatEndring
-import no.nav.syfo.domain.isLatestIkkeKandidat
-import no.nav.syfo.domain.IkkeAktuell
-import no.nav.syfo.domain.PersonIdentNumber
-import no.nav.syfo.infrastructure.database.IkkeAktuellRepository
-import no.nav.syfo.infrastructure.database.createIkkeAktuell
 import no.nav.syfo.infrastructure.database.toIkkeAktuellList
 
 class IkkeAktuellService(
     private val database: DatabaseInterface,
     private val dialogmotekandidatService: DialogmotekandidatService,
-    private val ikkeAktuellRepository: IkkeAktuellRepository,
+    private val ikkeAktuellRepository: IIkkeAktuellRepository,
     private val oppfolgingstilfelleService: OppfolgingstilfelleService,
 ) {
     suspend fun createIkkeAktuell(
@@ -32,7 +30,7 @@ class IkkeAktuellService(
                 throw ConflictException("Failed to create IkkeAktuell: Person is not kandidat")
             }
 
-            connection.createIkkeAktuell(ikkeAktuell)
+            ikkeAktuellRepository.createIkkeAktuell(connection = connection, commit = false, ikkeAktuell = ikkeAktuell)
             val latestOppfolgingstilfelleArbeidstaker = oppfolgingstilfelleService.getLatestOppfolgingstilfelle(
                 arbeidstakerPersonIdent = ikkeAktuell.personIdent,
                 veilederToken = veilederToken,
@@ -51,6 +49,6 @@ class IkkeAktuellService(
         }
     }
 
-    fun getIkkeAktuellList(personIdent: PersonIdentNumber): List<IkkeAktuell> =
+    suspend fun getIkkeAktuellList(personIdent: Personident): List<IkkeAktuell> =
         ikkeAktuellRepository.getIkkeAktuellListForPerson(personIdent = personIdent).toIkkeAktuellList()
 }

--- a/src/main/kotlin/no/nav/syfo/application/OppfolgingstilfelleService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/OppfolgingstilfelleService.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.application
 import no.nav.syfo.infrastructure.clients.oppfolgingstilfelle.OppfolgingstilfelleClient
 import no.nav.syfo.infrastructure.clients.oppfolgingstilfelle.toOppfolgingstilfelleList
 import no.nav.syfo.domain.Oppfolgingstilfelle
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.tilfelleForDate
 import java.time.LocalDate
 
@@ -11,7 +11,7 @@ class OppfolgingstilfelleService(
     private val oppfolgingstilfelleClient: OppfolgingstilfelleClient,
 ) {
     suspend fun getLatestOppfolgingstilfelle(
-        arbeidstakerPersonIdent: PersonIdentNumber,
+        arbeidstakerPersonIdent: Personident,
         veilederToken: String? = null,
         callId: String? = null,
     ) = getAllOppfolgingstilfeller(
@@ -21,7 +21,7 @@ class OppfolgingstilfelleService(
     ).firstOrNull()
 
     suspend fun getOppfolgingstilfelleForDate(
-        arbeidstakerPersonIdent: PersonIdentNumber,
+        arbeidstakerPersonIdent: Personident,
         date: LocalDate,
         veilederToken: String? = null,
         callId: String? = null,
@@ -32,7 +32,7 @@ class OppfolgingstilfelleService(
     ).tilfelleForDate(date)
 
     private suspend fun getAllOppfolgingstilfeller(
-        arbeidstakerPersonIdent: PersonIdentNumber,
+        arbeidstakerPersonIdent: Personident,
         veilederToken: String? = null,
         callId: String? = null,
     ): List<Oppfolgingstilfelle> {

--- a/src/main/kotlin/no/nav/syfo/application/UnntakService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/UnntakService.kt
@@ -6,7 +6,7 @@ import no.nav.syfo.infrastructure.database.dialogmotekandidat.getDialogmotekandi
 import no.nav.syfo.infrastructure.database.dialogmotekandidat.toDialogmotekandidatEndringList
 import no.nav.syfo.domain.DialogmotekandidatEndring
 import no.nav.syfo.domain.isLatestIkkeKandidat
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.infrastructure.database.createUnntak
 import no.nav.syfo.infrastructure.database.toUnntakList
 import no.nav.syfo.infrastructure.database.getUnntakList
@@ -50,7 +50,7 @@ class UnntakService(
         }
     }
 
-    fun getUnntakList(personIdent: PersonIdentNumber): List<Unntak> {
+    fun getUnntakList(personIdent: Personident): List<Unntak> {
         return database.getUnntakList(personIdent = personIdent).toUnntakList()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/domain/DialogmoteStatusEndring.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/DialogmoteStatusEndring.kt
@@ -13,7 +13,7 @@ enum class DialogmoteStatusEndringType {
 }
 
 data class DialogmoteStatusEndring private constructor(
-    val personIdentNumber: PersonIdentNumber,
+    val personIdentNumber: Personident,
     val type: DialogmoteStatusEndringType,
     val createdAt: OffsetDateTime,
     val moteTidspunkt: OffsetDateTime,
@@ -21,7 +21,7 @@ data class DialogmoteStatusEndring private constructor(
 ) {
     companion object {
         fun create(kafkaDialogmoteStatusEndring: KDialogmoteStatusEndring) = DialogmoteStatusEndring(
-            personIdentNumber = PersonIdentNumber(kafkaDialogmoteStatusEndring.getPersonIdent()),
+            personIdentNumber = Personident(kafkaDialogmoteStatusEndring.getPersonIdent()),
             type = DialogmoteStatusEndringType.valueOf(kafkaDialogmoteStatusEndring.getStatusEndringType()),
             createdAt = OffsetDateTime.now(),
             moteTidspunkt = OffsetDateTime.ofInstant(

--- a/src/main/kotlin/no/nav/syfo/domain/DialogmotekandidatEndring.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/DialogmotekandidatEndring.kt
@@ -20,13 +20,13 @@ enum class DialogmotekandidatEndringArsak {
 data class DialogmotekandidatEndring private constructor(
     val uuid: UUID,
     val createdAt: OffsetDateTime,
-    val personIdentNumber: PersonIdentNumber,
+    val personIdentNumber: Personident,
     val kandidat: Boolean,
     val arsak: DialogmotekandidatEndringArsak,
 ) {
     companion object {
         fun stoppunktKandidat(
-            personIdentNumber: PersonIdentNumber,
+            personIdentNumber: Personident,
         ) = create(
             personIdentNumber = personIdentNumber,
             kandidat = true,
@@ -43,7 +43,7 @@ data class DialogmotekandidatEndring private constructor(
             )
 
         fun ferdigstiltDialogmote(
-            personIdentNumber: PersonIdentNumber,
+            personIdentNumber: Personident,
         ) = create(
             personIdentNumber = personIdentNumber,
             kandidat = false,
@@ -51,7 +51,7 @@ data class DialogmotekandidatEndring private constructor(
         )
 
         fun lukketDialogmote(
-            personIdentNumber: PersonIdentNumber,
+            personIdentNumber: Personident,
         ) = create(
             personIdentNumber = personIdentNumber,
             kandidat = false,
@@ -59,7 +59,7 @@ data class DialogmotekandidatEndring private constructor(
         )
 
         fun unntak(
-            personIdentNumber: PersonIdentNumber,
+            personIdentNumber: Personident,
         ) = create(
             personIdentNumber = personIdentNumber,
             kandidat = false,
@@ -67,7 +67,7 @@ data class DialogmotekandidatEndring private constructor(
         )
 
         fun ikkeAktuell(
-            personIdentNumber: PersonIdentNumber,
+            personIdentNumber: Personident,
         ) = create(
             personIdentNumber = personIdentNumber,
             kandidat = false,
@@ -75,7 +75,7 @@ data class DialogmotekandidatEndring private constructor(
         )
 
         fun lukket(
-            personIdentNumber: PersonIdentNumber,
+            personIdentNumber: Personident,
         ) = create(
             personIdentNumber = personIdentNumber,
             kandidat = false,
@@ -83,7 +83,7 @@ data class DialogmotekandidatEndring private constructor(
         )
 
         private fun create(
-            personIdentNumber: PersonIdentNumber,
+            personIdentNumber: Personident,
             kandidat: Boolean,
             arsak: DialogmotekandidatEndringArsak,
         ) = DialogmotekandidatEndring(

--- a/src/main/kotlin/no/nav/syfo/domain/DialogmotekandidatStoppunkt.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/DialogmotekandidatStoppunkt.kt
@@ -21,7 +21,7 @@ enum class DialogmotekandidatStoppunktStatus {
 data class DialogmotekandidatStoppunkt private constructor(
     val uuid: UUID,
     val createdAt: OffsetDateTime,
-    val personIdent: PersonIdentNumber,
+    val personIdent: Personident,
     val processedAt: OffsetDateTime?,
     val status: DialogmotekandidatStoppunktStatus,
     val stoppunktPlanlagt: LocalDate,
@@ -39,7 +39,7 @@ data class DialogmotekandidatStoppunkt private constructor(
         }
 
         fun planlagt(
-            arbeidstakerPersonIdent: PersonIdentNumber,
+            arbeidstakerPersonIdent: Personident,
             tilfelleStart: LocalDate,
             tilfelleEnd: LocalDate,
         ) = DialogmotekandidatStoppunkt(

--- a/src/main/kotlin/no/nav/syfo/domain/IkkeAktuell.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/IkkeAktuell.kt
@@ -15,7 +15,7 @@ data class IkkeAktuell(
     val uuid: UUID,
     val createdAt: OffsetDateTime,
     val createdBy: String,
-    val personIdent: PersonIdentNumber,
+    val personIdent: Personident,
     val arsak: IkkeAktuellArsak,
     val beskrivelse: String?,
 )

--- a/src/main/kotlin/no/nav/syfo/domain/Oppfolgingstilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Oppfolgingstilfelle.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 
 data class Oppfolgingstilfelle(
-    val personIdent: PersonIdentNumber,
+    val personIdent: Personident,
     val tilfelleStart: LocalDate,
     val tilfelleEnd: LocalDate,
     val arbeidstakerAtTilfelleEnd: Boolean,

--- a/src/main/kotlin/no/nav/syfo/domain/Personident.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Personident.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.domain
 
-data class PersonIdentNumber(val value: String) {
+data class Personident(val value: String) {
     private val elevenDigits = Regex("^\\d{11}\$")
 
     init {

--- a/src/main/kotlin/no/nav/syfo/domain/Unntak.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Unntak.kt
@@ -21,14 +21,14 @@ data class Unntak private constructor(
     val uuid: UUID,
     val createdAt: OffsetDateTime,
     val createdBy: String,
-    val personIdent: PersonIdentNumber,
+    val personIdent: Personident,
     val arsak: UnntakArsak,
     val beskrivelse: String?,
 ) {
 
     constructor(
         createdBy: String,
-        personIdent: PersonIdentNumber,
+        personIdent: Personident,
         arsak: UnntakArsak,
         beskrivelse: String?,
     ) : this(
@@ -49,7 +49,7 @@ data class Unntak private constructor(
             uuid: UUID,
             createdAt: OffsetDateTime,
             createdBy: String,
-            personIdent: PersonIdentNumber,
+            personIdent: Personident,
             arsak: UnntakArsak,
             beskrivelse: String?,
         ) = Unntak(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/oppfolgingstilfelle/OppfolgingstilfelleClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/oppfolgingstilfelle/OppfolgingstilfelleClient.kt
@@ -10,7 +10,7 @@ import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.infrastructure.clients.ClientEnvironment
 import no.nav.syfo.infrastructure.clients.azuread.AzureAdClient
 import no.nav.syfo.infrastructure.clients.httpClientDefault
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.util.NAV_CALL_ID_HEADER
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.bearerHeader
@@ -29,7 +29,7 @@ class OppfolgingstilfelleClient(
         "${clientEnvironment.baseUrl}$ISOPPFOLGINGSTILFELLE_OPPFOLGINGSTILFELLE_VEILEDER_PERSON_PATH"
 
     suspend fun getOppfolgingstilfellePerson(
-        personIdent: PersonIdentNumber,
+        personIdent: Personident,
         veilederToken: String? = null,
         callId: String?,
     ): OppfolgingstilfellePersonDTO? {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/oppfolgingstilfelle/OppfolgingstilfellePersonDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/oppfolgingstilfelle/OppfolgingstilfellePersonDTO.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.infrastructure.clients.oppfolgingstilfelle
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.domain.Oppfolgingstilfelle
 import no.nav.syfo.util.isBeforeOrEqual
@@ -21,7 +21,7 @@ data class OppfolgingstilfelleDTO(
 )
 
 fun OppfolgingstilfelleDTO.toOppfolgingstilfelle(
-    personIdent: PersonIdentNumber,
+    personIdent: Personident,
     dodsdato: LocalDate?,
 ) = Oppfolgingstilfelle(
     personIdent = personIdent,
@@ -32,7 +32,7 @@ fun OppfolgingstilfelleDTO.toOppfolgingstilfelle(
     dodsdato = dodsdato,
 )
 
-fun OppfolgingstilfellePersonDTO?.toOppfolgingstilfelleList(personIdent: PersonIdentNumber): List<Oppfolgingstilfelle> =
+fun OppfolgingstilfellePersonDTO?.toOppfolgingstilfelleList(personIdent: Personident): List<Oppfolgingstilfelle> =
     this?.oppfolgingstilfelleList
         ?.filter { it.start.isBeforeOrEqual(tomorrow()) }
         ?.map {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/pdl/PdlClient.kt
@@ -8,7 +8,7 @@ import io.ktor.http.*
 import no.nav.syfo.infrastructure.clients.ClientEnvironment
 import no.nav.syfo.infrastructure.clients.azuread.AzureAdClient
 import no.nav.syfo.infrastructure.clients.httpClientDefault
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.infrastructure.clients.pdl.domain.IdentType
 import no.nav.syfo.infrastructure.clients.pdl.domain.PdlHentIdenter
 import no.nav.syfo.infrastructure.clients.pdl.domain.PdlHentIdenterRequest
@@ -25,7 +25,7 @@ class PdlClient(
 ) {
 
     suspend fun getPdlIdenter(
-        personIdent: PersonIdentNumber,
+        personIdent: Personident,
         callId: String? = null,
     ): PdlHentIdenter? {
         val token = azureAdClient.getSystemToken(pdlEnvironment.clientId)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -9,7 +9,7 @@ import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.infrastructure.clients.ClientEnvironment
 import no.nav.syfo.infrastructure.clients.azuread.AzureAdClient
 import no.nav.syfo.infrastructure.clients.httpClientDefault
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.util.NAV_CALL_ID_HEADER
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.bearerHeader
@@ -25,7 +25,7 @@ class VeilederTilgangskontrollClient(
 
     suspend fun hasAccess(
         callId: String,
-        personIdent: PersonIdentNumber,
+        personIdent: Personident,
         token: String,
     ): Boolean {
         val onBehalfOfToken = azureAdClient.getOnBehalfOfToken(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/DialogmoteStatusQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/DialogmoteStatusQuery.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.infrastructure.database
 
 import no.nav.syfo.domain.DialogmoteStatusEndring
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import java.sql.Connection
 import java.time.OffsetDateTime
 import java.util.*
@@ -51,7 +51,7 @@ const val queryGetLatestDialogmoteFerdigstiltForPerson =
     """
 
 fun Connection.getLatestDialogmoteFerdigstiltForPerson(
-    personIdent: PersonIdentNumber,
+    personIdent: Personident,
 ): OffsetDateTime? {
     val dateTimeList = prepareStatement(queryGetLatestDialogmoteFerdigstiltForPerson).use {
         it.setString(1, personIdent.value)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/IdenthendelseQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/IdenthendelseQuery.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.infrastructure.database
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import java.sql.Connection
 import java.sql.PreparedStatement
 
@@ -12,8 +12,8 @@ const val queryUpdateKandidatStoppunkt =
     """
 
 fun Connection.updateKandidatStoppunkt(
-    nyPersonident: PersonIdentNumber,
-    inactiveIdenter: List<PersonIdentNumber>,
+    nyPersonident: Personident,
+    inactiveIdenter: List<Personident>,
     commit: Boolean = false,
 ): Int {
     var updatedRows = 0
@@ -38,8 +38,8 @@ const val queryUpdateKandidatEndring =
     """
 
 fun Connection.updateKandidatEndring(
-    nyPersonident: PersonIdentNumber,
-    inactiveIdenter: List<PersonIdentNumber>,
+    nyPersonident: Personident,
+    inactiveIdenter: List<Personident>,
     commit: Boolean = false,
 ): Int {
     var updatedRows = 0
@@ -64,8 +64,8 @@ const val queryUpdateUnntak =
     """
 
 fun Connection.updateUnntak(
-    nyPersonident: PersonIdentNumber,
-    inactiveIdenter: List<PersonIdentNumber>,
+    nyPersonident: Personident,
+    inactiveIdenter: List<Personident>,
     commit: Boolean = false,
 ): Int {
     var updatedRows = 0
@@ -90,8 +90,8 @@ const val queryUpdateDialogmoteStatus =
     """
 
 fun Connection.updateDialogmoteStatus(
-    nyPersonident: PersonIdentNumber,
-    inactiveIdenter: List<PersonIdentNumber>,
+    nyPersonident: Personident,
+    inactiveIdenter: List<Personident>,
     commit: Boolean = false,
 ): Int {
     var updatedRows = 0
@@ -124,7 +124,7 @@ const val queryGetIdentCount =
     """
 
 fun DatabaseInterface.getIdentCount(
-    identer: List<PersonIdentNumber>,
+    identer: List<Personident>,
 ): Int =
     this.connection.use { connection ->
         connection.prepareStatement(queryGetIdentCount).use<PreparedStatement, Int> {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/IkkeAktuellRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/IkkeAktuellRepository.kt
@@ -1,13 +1,17 @@
 package no.nav.syfo.infrastructure.database
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.application.IIkkeAktuellRepository
+import no.nav.syfo.domain.IkkeAktuell
+import no.nav.syfo.domain.Personident
+import java.sql.Connection
 import java.sql.ResultSet
 import java.time.OffsetDateTime
 import java.util.*
+import kotlin.use
 
-class IkkeAktuellRepository(private val database: DatabaseInterface) {
+class IkkeAktuellRepository(private val database: DatabaseInterface) : IIkkeAktuellRepository {
 
-    fun getIkkeAktuellListForPerson(personIdent: PersonIdentNumber): List<PIkkeAktuell> =
+    override suspend fun getIkkeAktuellListForPerson(personIdent: Personident): List<PIkkeAktuell> =
         database.connection.use { connection ->
             connection.prepareStatement(GET_IKKE_AKTUELL_FOR_PERSON).use {
                 it.setString(1, personIdent.value)
@@ -15,17 +19,48 @@ class IkkeAktuellRepository(private val database: DatabaseInterface) {
             }
         }
 
+    override suspend fun createIkkeAktuell(connection: Connection, commit: Boolean, ikkeAktuell: IkkeAktuell) {
+        val idList = connection.prepareStatement(QUERY_CREATE_IKKE_AKTUELL).use {
+            it.setString(1, ikkeAktuell.uuid.toString())
+            it.setObject(2, ikkeAktuell.createdAt)
+            it.setString(3, ikkeAktuell.createdBy)
+            it.setString(4, ikkeAktuell.personIdent.value)
+            it.setString(5, ikkeAktuell.arsak.name)
+            it.setString(6, ikkeAktuell.beskrivelse)
+            it.executeQuery().toList { getInt("id") }
+        }
+
+        if (idList.size != 1) {
+            throw NoElementInsertedException("Creating IKKEAKTUELL failed, no rows affected.")
+        }
+        if (commit) connection.commit()
+    }
+
     companion object {
         private const val GET_IKKE_AKTUELL_FOR_PERSON =
             """
-                    SELECT * 
-                    FROM IKKE_AKTUELL
-                    WHERE personident = ?
-                """
+                SELECT * 
+                FROM IKKE_AKTUELL
+                WHERE personident = ?
+            """
+
+        private const val QUERY_CREATE_IKKE_AKTUELL =
+            """
+                INSERT INTO IKKE_AKTUELL (
+                    id,
+                    uuid,
+                    created_at,
+                    created_by,
+                    personident,
+                    arsak,
+                    beskrivelse
+                ) values (DEFAULT, ?, ?, ?, ?, ?, ?)
+                RETURNING id
+            """
     }
 }
 
-fun ResultSet.toPIkkeAktuell() = PIkkeAktuell(
+private fun ResultSet.toPIkkeAktuell() = PIkkeAktuell(
     id = getInt("id"),
     uuid = UUID.fromString(getString("uuid")),
     createdAt = getObject("created_at", OffsetDateTime::class.java),

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/PIkkeAktuell.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/PIkkeAktuell.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.infrastructure.database
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.IkkeAktuell
 import no.nav.syfo.domain.IkkeAktuellArsak
 import java.time.OffsetDateTime
@@ -21,7 +21,7 @@ fun List<PIkkeAktuell>.toIkkeAktuellList() = this.map {
         uuid = it.uuid,
         createdAt = it.createdAt,
         createdBy = it.createdBy,
-        personIdent = PersonIdentNumber(it.personIdent),
+        personIdent = Personident(it.personIdent),
         arsak = IkkeAktuellArsak.valueOf(it.arsak),
         beskrivelse = it.beskrivelse,
     )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/PUnntak.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/PUnntak.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.infrastructure.database
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Unntak
 import no.nav.syfo.domain.UnntakArsak
 import java.time.OffsetDateTime
@@ -21,7 +21,7 @@ fun List<PUnntak>.toUnntakList() = this.map { pUnntak ->
         uuid = pUnntak.uuid,
         createdAt = pUnntak.createdAt,
         createdBy = pUnntak.createdBy,
-        personIdent = PersonIdentNumber(pUnntak.personIdent),
+        personIdent = Personident(pUnntak.personIdent),
         arsak = UnntakArsak.valueOf(pUnntak.arsak),
         beskrivelse = pUnntak.beskrivelse,
     )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/UnntakQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/UnntakQuery.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.infrastructure.database
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Unntak
 import java.sql.Connection
 import java.sql.ResultSet
@@ -46,7 +46,7 @@ const val queryGetUnntakForPerson: String =
     """
 
 fun DatabaseInterface.getUnntakList(
-    personIdent: PersonIdentNumber,
+    personIdent: Personident,
 ): List<PUnntak> = this.connection.use { connection ->
     connection.prepareStatement(queryGetUnntakForPerson).use {
         it.setString(1, personIdent.value)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/dialogmotekandidat/DialogmotekandidatEndringQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/dialogmotekandidat/DialogmotekandidatEndringQuery.kt
@@ -4,7 +4,7 @@ import no.nav.syfo.infrastructure.database.DatabaseInterface
 import no.nav.syfo.infrastructure.database.NoElementInsertedException
 import no.nav.syfo.infrastructure.database.toList
 import no.nav.syfo.domain.DialogmotekandidatEndring
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import java.sql.Connection
 import java.sql.Timestamp
 import java.time.Instant
@@ -50,7 +50,7 @@ const val queryGetDialogmotekandidatEndringForPerson =
     """
 
 fun Connection.getDialogmotekandidatEndringListForPerson(
-    personIdent: PersonIdentNumber,
+    personIdent: Personident,
 ): List<PDialogmotekandidatEndring> = prepareStatement(queryGetDialogmotekandidatEndringForPerson).use {
     it.setString(1, personIdent.value)
     it.executeQuery().toList { toPDialogmotekandidatEndringList() }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/dialogmotekandidat/DialogmotekandidatRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/dialogmotekandidat/DialogmotekandidatRepository.kt
@@ -2,7 +2,7 @@ package no.nav.syfo.infrastructure.database.dialogmotekandidat
 
 import no.nav.syfo.infrastructure.database.DatabaseInterface
 import no.nav.syfo.infrastructure.database.toList
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import java.sql.ResultSet
 import java.time.OffsetDateTime
 import java.util.*
@@ -32,7 +32,7 @@ fun ResultSet.toPDialogmotekandidatEndringList() =
         id = getInt("id"),
         uuid = UUID.fromString(getString("uuid")),
         createdAt = getObject("created_at", OffsetDateTime::class.java),
-        personIdent = PersonIdentNumber(getString("personident")),
+        personIdent = Personident(getString("personident")),
         kandidat = getBoolean("kandidat"),
         arsak = getString("arsak"),
     )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/dialogmotekandidat/DialogmotekandidatStoppunktQuery.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/dialogmotekandidat/DialogmotekandidatStoppunktQuery.kt
@@ -2,7 +2,7 @@ package no.nav.syfo.infrastructure.database.dialogmotekandidat
 
 import no.nav.syfo.domain.DialogmotekandidatStoppunkt
 import no.nav.syfo.domain.DialogmotekandidatStoppunktStatus
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.infrastructure.database.DatabaseInterface
 import no.nav.syfo.infrastructure.database.NoElementInsertedException
 import no.nav.syfo.infrastructure.database.toList
@@ -61,7 +61,7 @@ const val queryGetDialogmotekandidatStoppunkt =
     """
 
 fun DatabaseInterface.getDialogmotekandidatStoppunktList(
-    arbeidstakerPersonIdent: PersonIdentNumber,
+    arbeidstakerPersonIdent: Personident,
 ): List<PDialogmotekandidatStoppunkt> =
     this.connection.use { connection ->
         connection.prepareStatement(queryGetDialogmotekandidatStoppunkt).use {
@@ -114,7 +114,7 @@ fun ResultSet.toPDialogmotekandidatStoppunktList(): PDialogmotekandidatStoppunkt
         id = getInt("id"),
         uuid = UUID.fromString(getString("uuid")),
         createdAt = getObject("created_at", OffsetDateTime::class.java),
-        personIdent = PersonIdentNumber(getString("personident")),
+        personIdent = Personident(getString("personident")),
         processedAt = getObject("processed_at", OffsetDateTime::class.java),
         status = getString("status"),
         stoppunktPlanlagt = getDate("stoppunkt_planlagt").toLocalDate(),

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/dialogmotekandidat/PDialogmotekandidatEndring.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/dialogmotekandidat/PDialogmotekandidatEndring.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.infrastructure.database.dialogmotekandidat
 
 import no.nav.syfo.domain.DialogmotekandidatEndring
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -9,7 +9,7 @@ data class PDialogmotekandidatEndring(
     val id: Int,
     val uuid: UUID,
     val createdAt: OffsetDateTime,
-    val personIdent: PersonIdentNumber,
+    val personIdent: Personident,
     val kandidat: Boolean,
     val arsak: String,
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/dialogmotekandidat/PDialogmotekandidatStoppunkt.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/dialogmotekandidat/PDialogmotekandidatStoppunkt.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.infrastructure.database.dialogmotekandidat
 
 import no.nav.syfo.domain.DialogmotekandidatStoppunkt
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
@@ -10,7 +10,7 @@ data class PDialogmotekandidatStoppunkt(
     val id: Int,
     val uuid: UUID,
     val createdAt: OffsetDateTime,
-    val personIdent: PersonIdentNumber,
+    val personIdent: Personident,
     val processedAt: OffsetDateTime?,
     val status: String,
     val stoppunktPlanlagt: LocalDate,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/KafkaIdenthendelseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/KafkaIdenthendelseDTO.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.infrastructure.kafka.identhendelse
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 
 // Basert på https://github.com/navikt/pdl/blob/master/libs/contract-pdl-avro/src/main/avro/no/nav/person/pdl/aktor/AktorV2.avdl
 
@@ -9,13 +9,13 @@ data class KafkaIdenthendelseDTO(
 ) {
     val folkeregisterIdenter: List<Identifikator> = identifikatorer.filter { it.type == IdentType.FOLKEREGISTERIDENT }
 
-    fun getActivePersonident(): PersonIdentNumber? = folkeregisterIdenter
+    fun getActivePersonident(): Personident? = folkeregisterIdenter
         .find { it.gjeldende }
-        ?.let { PersonIdentNumber(it.idnummer) }
+        ?.let { Personident(it.idnummer) }
 
-    fun getInactivePersonidenter(): List<PersonIdentNumber> = folkeregisterIdenter
+    fun getInactivePersonidenter(): List<Personident> = folkeregisterIdenter
         .filter { !it.gjeldende }
-        .map { PersonIdentNumber(it.idnummer) }
+        .map { Personident(it.idnummer) }
 }
 
 data class Identifikator(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/oppfolgingstilfelle/KafkaOppfolgingstilfellePerson.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/oppfolgingstilfelle/KafkaOppfolgingstilfellePerson.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.infrastructure.kafka.oppfolgingstilfelle
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.domain.Oppfolgingstilfelle
 import no.nav.syfo.util.*
@@ -27,7 +27,7 @@ data class KafkaOppfolgingstilfelle(
 fun KafkaOppfolgingstilfellePerson.toOppfolgingstilfelle(
     tilfelle: KafkaOppfolgingstilfelle,
 ) = Oppfolgingstilfelle(
-    personIdent = PersonIdentNumber(this.personIdentNumber),
+    personIdent = Personident(this.personIdentNumber),
     tilfelleStart = tilfelle.start,
     tilfelleEnd = tilfelle.end,
     arbeidstakerAtTilfelleEnd = tilfelle.arbeidstakerAtTilfelleEnd,

--- a/src/main/kotlin/no/nav/syfo/util/VeilederAPIAccessPipeline.kt
+++ b/src/main/kotlin/no/nav/syfo/util/VeilederAPIAccessPipeline.kt
@@ -3,11 +3,11 @@ package no.nav.syfo.util
 import io.ktor.server.routing.*
 import no.nav.syfo.api.exception.ForbiddenAccessVeilederException
 import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 
 suspend fun RoutingContext.validateVeilederAccess(
     action: String,
-    personIdentToAccess: PersonIdentNumber,
+    personIdentToAccess: Personident,
     veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
     requestBlock: suspend () -> Unit,
 ) {

--- a/src/test/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/cronjob/dialogmotekandidat/DialogmotekandidatOutdatedCronjobSpek.kt
@@ -8,7 +8,7 @@ import no.nav.syfo.infrastructure.database.dialogmotekandidat.getDialogmotekandi
 import no.nav.syfo.domain.DialogmotekandidatEndringArsak
 import no.nav.syfo.infrastructure.kafka.dialogmotekandidat.DialogmotekandidatEndringProducer
 import no.nav.syfo.infrastructure.kafka.dialogmotekandidat.KafkaDialogmotekandidatEndring
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.infrastructure.cronjob.dialogmotekandidat.DialogmotekandidatOutdatedCronjob
 import no.nav.syfo.oppfolgingstilfelle.toOffsetDatetime
 import no.nav.syfo.testhelper.ExternalMockEnvironment
@@ -46,7 +46,7 @@ class DialogmotekandidatOutdatedCronjobSpek : Spek({
         dialogmotekandidatService = dialogmotekandidatService,
     )
 
-    fun getDialogmotekandidatEndringer(personIdent: PersonIdentNumber): List<PDialogmotekandidatEndring> =
+    fun getDialogmotekandidatEndringer(personIdent: Personident): List<PDialogmotekandidatEndring> =
         database.connection.use { connection -> connection.getDialogmotekandidatEndringListForPerson(personIdent) }
 
     beforeEachTest {

--- a/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
@@ -8,7 +8,7 @@ import no.nav.syfo.infrastructure.database.dialogmotekandidat.createDialogmoteka
 import no.nav.syfo.infrastructure.database.createDialogmoteStatus
 import no.nav.syfo.domain.DialogmoteStatusEndring
 import no.nav.syfo.domain.DialogmoteStatusEndringType
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.infrastructure.database.getIdentCount
 import no.nav.syfo.testhelper.ExternalMockEnvironment
 import no.nav.syfo.testhelper.UserConstants
@@ -103,7 +103,7 @@ object IdenthendelseServiceSpek : Spek({
     }
 })
 
-fun populateDatabase(oldIdent: PersonIdentNumber, database: DatabaseInterface, updateInAllTables: Boolean = true) {
+fun populateDatabase(oldIdent: Personident, database: DatabaseInterface, updateInAllTables: Boolean = true) {
     val stoppunkt = generateDialogmotekandidatStoppunktPlanlagt(oldIdent, LocalDate.now())
     val endring = generateDialogmotekandidatEndringStoppunkt(oldIdent)
 

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -7,7 +7,7 @@ import no.nav.syfo.domain.ARENA_CUTOFF
 import no.nav.syfo.domain.DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS
 import no.nav.syfo.domain.DialogmotekandidatStoppunkt
 import no.nav.syfo.domain.DialogmotekandidatStoppunktStatus
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.infrastructure.kafka.oppfolgingstilfelle.KafkaOppfolgingstilfelle
 import no.nav.syfo.infrastructure.kafka.oppfolgingstilfelle.KafkaOppfolgingstilfellePerson
 import no.nav.syfo.infrastructure.kafka.oppfolgingstilfelle.KafkaOppfolgingstilfellePersonService
@@ -192,7 +192,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
 
                 val dialogmotekandidatStoppunktList =
                     database.getDialogmotekandidatStoppunktList(
-                        arbeidstakerPersonIdent = PersonIdentNumber(
+                        arbeidstakerPersonIdent = Personident(
                             kafkaOppfolgingstilfellePersonDialogmotekandidatFirst.personIdentNumber
                         )
                     ).toDialogmotekandidatStoppunktList()
@@ -228,7 +228,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
 
                 val dialogmotekandidatStoppunktList =
                     database.getDialogmotekandidatStoppunktList(
-                        arbeidstakerPersonIdent = PersonIdentNumber(
+                        arbeidstakerPersonIdent = Personident(
                             kafkaOppfolgingstilfellePersonVanligOgFramtidig.personIdentNumber
                         )
                     ).toDialogmotekandidatStoppunktList()
@@ -270,7 +270,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
 
                 val dialogmotekandidatStoppunktList: List<DialogmotekandidatStoppunkt> =
                     database.getDialogmotekandidatStoppunktList(
-                        arbeidstakerPersonIdent = PersonIdentNumber(
+                        arbeidstakerPersonIdent = Personident(
                             kafkaOppfolgingstilfellePersonDialogmotekandidatFirst.personIdentNumber
                         )
                     ).toDialogmotekandidatStoppunktList()
@@ -309,7 +309,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
 
                 val dialogmotekandidatStoppunktList: List<DialogmotekandidatStoppunkt> =
                     database.getDialogmotekandidatStoppunktList(
-                        arbeidstakerPersonIdent = PersonIdentNumber(
+                        arbeidstakerPersonIdent = Personident(
                             kafkaOppfolgingstilfellePersonTilbakedatertLast.personIdentNumber
                         )
                     ).toDialogmotekandidatStoppunktList()
@@ -347,7 +347,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
 
                 val dialogmotekandidatStoppunktList: List<DialogmotekandidatStoppunkt> =
                     database.getDialogmotekandidatStoppunktList(
-                        arbeidstakerPersonIdent = PersonIdentNumber(
+                        arbeidstakerPersonIdent = Personident(
                             kafkaOppfolgingstilfellePersonTilbakedatertLast.personIdentNumber
                         )
                     ).toDialogmotekandidatStoppunktList()
@@ -398,7 +398,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                 }
                 val dialogmotekandidatStoppunktList =
                     database.getDialogmotekandidatStoppunktList(
-                        arbeidstakerPersonIdent = PersonIdentNumber(
+                        arbeidstakerPersonIdent = Personident(
                             kafkaOppfolgingstilfellePersonDialogmotekandidatFirst.personIdentNumber
                         )
                     ).toDialogmotekandidatStoppunktList()
@@ -439,7 +439,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                 }
                 val dialogmotekandidatStoppunktList =
                     database.getDialogmotekandidatStoppunktList(
-                        arbeidstakerPersonIdent = PersonIdentNumber(
+                        arbeidstakerPersonIdent = Personident(
                             kafkaOppfolgingstilfellePersonDialogmotekandidatWithDodsdato.personIdentNumber
                         )
                     ).toDialogmotekandidatStoppunktList()
@@ -524,7 +524,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                 }
 
                 val dialogmotekandidatStoppunktList = database.getDialogmotekandidatStoppunktList(
-                    arbeidstakerPersonIdent = PersonIdentNumber(
+                    arbeidstakerPersonIdent = Personident(
                         kafkaOppfolgingstilfellePersonDialogmotekandidatFirst.personIdentNumber,
                     ),
                 ).toDialogmotekandidatStoppunktList()
@@ -588,7 +588,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                 }
 
                 val dialogmotekandidatStoppunktList = database.getDialogmotekandidatStoppunktList(
-                    arbeidstakerPersonIdent = PersonIdentNumber(
+                    arbeidstakerPersonIdent = Personident(
                         kafkaOppfolgingstilfellePersonDialogmotekandidatFirst.personIdentNumber,
                     ),
                 ).toDialogmotekandidatStoppunktList()

--- a/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.testhelper
 
 import no.nav.syfo.ApplicationState
 import no.nav.syfo.infrastructure.clients.wellknown.WellKnown
+import no.nav.syfo.infrastructure.database.IkkeAktuellRepository
 import no.nav.syfo.testhelper.mock.*
 import java.nio.file.Paths
 
@@ -20,6 +21,7 @@ class ExternalMockEnvironment private constructor() {
     val environment = testEnvironment()
     val mockHttpClient = mockHttpClient(environment = environment)
     val wellKnownInternalAzureAD = wellKnownInternalAzureAD()
+    val ikkeAktuellRepository = IkkeAktuellRepository(database = database)
 
     companion object {
         val instance: ExternalMockEnvironment = ExternalMockEnvironment()

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
@@ -7,7 +7,7 @@ import no.nav.syfo.infrastructure.database.dialogmotekandidat.getDialogmotekandi
 import no.nav.syfo.infrastructure.database.dialogmotekandidat.toDialogmotekandidatEndringList
 import no.nav.syfo.domain.DialogmotekandidatEndring
 import no.nav.syfo.domain.isLatestIkkeKandidat
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import org.flywaydb.core.Flyway
 import java.sql.Connection
 
@@ -66,7 +66,7 @@ fun DatabaseInterface.createDialogmotekandidatEndring(dialogmotekandidatEndring:
     }
 }
 
-fun DatabaseInterface.isIkkeKandidat(personIdentNumber: PersonIdentNumber) =
+fun DatabaseInterface.isIkkeKandidat(personIdentNumber: Personident) =
     connection.getDialogmotekandidatEndringListForPerson(personIdent = personIdentNumber)
         .toDialogmotekandidatEndringList()
         .isLatestIkkeKandidat()

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -1,17 +1,18 @@
 package no.nav.syfo.testhelper
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Virksomhetsnummer
 
 object UserConstants {
-    val ARBEIDSTAKER_PERSONIDENTNUMBER = PersonIdentNumber("12345678912")
-    val ARBEIDSTAKER_PERSONIDENTNUMBER_NOT_KANDIDAT = PersonIdentNumber("12345678912".replace("2", "8"))
-    val ARBEIDSTAKER_PERSONIDENTNUMBER_OLD_KANDIDAT = PersonIdentNumber("12345678912".replace("3", "7"))
-    val ARBEIDSTAKER_PERSONIDENTNUMBER_DOD = PersonIdentNumber("12345678912".replace("4", "6"))
-    val PERSONIDENTNUMBER_VEILEDER_NO_ACCESS = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENTNUMBER.value.replace("2", "3"))
-    val ARBEIDSTAKER_2_PERSONIDENTNUMBER = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENTNUMBER.value.replace("2", "1"))
-    val ARBEIDSTAKER_3_PERSONIDENTNUMBER = PersonIdentNumber("12345678913")
-    val FEILENDE_PERSONIDENTNUMBER = PersonIdentNumber("12345670000")
+    val ARBEIDSTAKER_PERSONIDENTNUMBER = Personident("12345678912")
+    val ARBEIDSTAKER_PERSONIDENTNUMBER_ALTERNATIVE = Personident("12345678919")
+    val ARBEIDSTAKER_PERSONIDENTNUMBER_NOT_KANDIDAT = Personident("12345678912".replace("2", "8"))
+    val ARBEIDSTAKER_PERSONIDENTNUMBER_OLD_KANDIDAT = Personident("12345678912".replace("3", "7"))
+    val ARBEIDSTAKER_PERSONIDENTNUMBER_DOD = Personident("12345678912".replace("4", "6"))
+    val PERSONIDENTNUMBER_VEILEDER_NO_ACCESS = Personident(ARBEIDSTAKER_PERSONIDENTNUMBER.value.replace("2", "3"))
+    val ARBEIDSTAKER_2_PERSONIDENTNUMBER = Personident(ARBEIDSTAKER_PERSONIDENTNUMBER.value.replace("2", "1"))
+    val ARBEIDSTAKER_3_PERSONIDENTNUMBER = Personident("12345678913")
+    val FEILENDE_PERSONIDENTNUMBER = Personident("12345670000")
 
     val VIRKSOMHETSNUMMER_DEFAULT = Virksomhetsnummer("987654321")
     const val VEILEDER_IDENT = "Z999999"

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmotekandidatGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/DialogmotekandidatGenerator.kt
@@ -3,11 +3,11 @@ package no.nav.syfo.testhelper.generator
 import no.nav.syfo.domain.DIALOGMOTEKANDIDAT_STOPPUNKT_DURATION_DAYS
 import no.nav.syfo.domain.DialogmotekandidatEndring
 import no.nav.syfo.domain.DialogmotekandidatStoppunkt
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import java.time.LocalDate
 
 fun generateDialogmotekandidatStoppunktPlanlagt(
-    arbeidstakerPersonIdent: PersonIdentNumber,
+    arbeidstakerPersonIdent: Personident,
     planlagt: LocalDate,
 ): DialogmotekandidatStoppunkt = DialogmotekandidatStoppunkt.planlagt(
     arbeidstakerPersonIdent = arbeidstakerPersonIdent,
@@ -16,13 +16,13 @@ fun generateDialogmotekandidatStoppunktPlanlagt(
 )
 
 fun generateDialogmotekandidatEndringStoppunkt(
-    personIdentNumber: PersonIdentNumber,
+    personIdentNumber: Personident,
 ): DialogmotekandidatEndring = DialogmotekandidatEndring.stoppunktKandidat(
     personIdentNumber = personIdentNumber
 )
 
 fun generateDialogmotekandidatEndringFerdigstilt(
-    personIdentNumber: PersonIdentNumber,
+    personIdentNumber: Personident,
 ): DialogmotekandidatEndring = DialogmotekandidatEndring.ferdigstiltDialogmote(
     personIdentNumber = personIdentNumber
 )

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/KafkaDialogmoteStatusEndringGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/KafkaDialogmoteStatusEndringGenerator.kt
@@ -2,11 +2,11 @@ package no.nav.syfo.testhelper.generator
 
 import no.nav.syfo.dialogmote.avro.KDialogmoteStatusEndring
 import no.nav.syfo.domain.DialogmoteStatusEndringType
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import java.time.OffsetDateTime
 
 fun generateKDialogmoteStatusEndring(
-    personIdentNumber: PersonIdentNumber,
+    personIdentNumber: Personident,
     statusEndringType: DialogmoteStatusEndringType,
     moteTidspunkt: OffsetDateTime,
     endringsTidspunkt: OffsetDateTime,

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/KafkaIdenthendelseDTOGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/KafkaIdenthendelseDTOGenerator.kt
@@ -1,13 +1,13 @@
 package no.nav.syfo.testhelper.generator
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.infrastructure.kafka.identhendelse.IdentType
 import no.nav.syfo.infrastructure.kafka.identhendelse.Identifikator
 import no.nav.syfo.infrastructure.kafka.identhendelse.KafkaIdenthendelseDTO
 import no.nav.syfo.testhelper.UserConstants
 
 fun generateKafkaIdenthendelseDTO(
-    personident: PersonIdentNumber = UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER,
+    personident: Personident = UserConstants.ARBEIDSTAKER_PERSONIDENTNUMBER,
     hasOldPersonident: Boolean,
 ): KafkaIdenthendelseDTO {
     val identifikatorer = mutableListOf(

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/KafkaOppfolgingstilfelleArbeidstakerGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/KafkaOppfolgingstilfelleArbeidstakerGenerator.kt
@@ -1,6 +1,6 @@
 package no.nav.syfo.testhelper.generator
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.infrastructure.kafka.oppfolgingstilfelle.KafkaOppfolgingstilfelle
 import no.nav.syfo.infrastructure.kafka.oppfolgingstilfelle.KafkaOppfolgingstilfellePerson
@@ -12,7 +12,7 @@ import java.util.*
 
 fun generateKafkaOppfolgingstilfellePerson(
     arbeidstakerAtTilfelleEnd: Boolean = true,
-    personIdentNumber: PersonIdentNumber = ARBEIDSTAKER_PERSONIDENTNUMBER,
+    personIdentNumber: Personident = ARBEIDSTAKER_PERSONIDENTNUMBER,
     start: LocalDate = LocalDate.now().minusDays(1),
     oppfolgingstilfelleDurationInDays: Long,
     virksomhetsnummer: Virksomhetsnummer = VIRKSOMHETSNUMMER_DEFAULT,

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/OppfolgingstilfelleGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/OppfolgingstilfelleGenerator.kt
@@ -1,11 +1,11 @@
 package no.nav.syfo.testhelper.generator
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.Oppfolgingstilfelle
 import java.time.LocalDate
 
 fun generateOppfolgingstilfelle(
-    arbeidstakerPersonIdent: PersonIdentNumber,
+    arbeidstakerPersonIdent: Personident,
     oppfolgingstilfelleDurationInDays: Long,
     backdatedNumberOfDays: Long = 0,
 ) = Oppfolgingstilfelle(

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/UnntakGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/UnntakGenerator.kt
@@ -1,11 +1,11 @@
 package no.nav.syfo.testhelper.generator
 
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.api.CreateUnntakDTO
 import no.nav.syfo.domain.UnntakArsak
 
 fun generateNewUnntakDTO(
-    personIdent: PersonIdentNumber,
+    personIdent: Personident,
     arsak: UnntakArsak = UnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
 ) = CreateUnntakDTO(
     personIdent = personIdent.value,

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.testhelper.mock
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.infrastructure.clients.pdl.domain.IdentType
 import no.nav.syfo.infrastructure.clients.pdl.domain.PdlHentIdenter
 import no.nav.syfo.infrastructure.clients.pdl.domain.PdlHentIdenterRequest
@@ -14,9 +14,9 @@ import no.nav.syfo.testhelper.UserConstants
 
 suspend fun MockRequestHandleScope.pdlMockResponse(request: HttpRequestData): HttpResponseData {
     val pdlRequest = request.receiveBody<PdlHentIdenterRequest>()
-    return when (val personIdent = PersonIdentNumber(pdlRequest.variables.ident)) {
+    return when (val personIdent = Personident(pdlRequest.variables.ident)) {
         UserConstants.ARBEIDSTAKER_3_PERSONIDENTNUMBER -> {
-            respond(generatePdlIdenterResponse(PersonIdentNumber("11111111111")))
+            respond(generatePdlIdenterResponse(Personident("11111111111")))
         }
         UserConstants.FEILENDE_PERSONIDENTNUMBER -> {
             respond(HttpStatusCode.InternalServerError)
@@ -28,7 +28,7 @@ suspend fun MockRequestHandleScope.pdlMockResponse(request: HttpRequestData): Ht
 }
 
 private fun generatePdlIdenterResponse(
-    personIdentNumber: PersonIdentNumber,
+    personIdentNumber: Personident,
 ) = PdlIdenterResponse(
     data = PdlHentIdenter(
         hentIdenter = PdlIdenter(
@@ -49,12 +49,12 @@ private fun generatePdlIdenterResponse(
     errors = null,
 )
 
-private fun PersonIdentNumber.toHistoricalPersonIdentNumber(): PersonIdentNumber {
+private fun Personident.toHistoricalPersonIdentNumber(): Personident {
     val firstDigit = this.value[0].digitToInt()
     val newDigit = firstDigit + 4
     val dNummer = this.value.replace(
         firstDigit.toString(),
         newDigit.toString(),
     )
-    return PersonIdentNumber(dNummer)
+    return Personident(dNummer)
 }


### PR DESCRIPTION
- Legger til endepunkt for å hente ikkeaktuell vurderinger, slik at de kan vises i dialogmøtehistorikk.
- La til interface for `IkkeAktuellRepository`
- Renamet `PersonIdentNumber` til `Personident` som vi kaller det i de fleste andre apper.

Kommer tilhørende PR i `syfomodiaperson`